### PR TITLE
Use current year dynamically instead of hard-coding it

### DIFF
--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -20,7 +20,7 @@ export default function SchedulePage({ competitions }) {
         <title>Schedule</title>
         <meta
           name="description"
-          content={`Full schedule for the 2026 season of ${process.env.NEXT_PUBLIC_INTRO_TITLE}.`}
+          content={`Full schedule for the ${new Date().getFullYear()} season of ${process.env.NEXT_PUBLIC_INTRO_TITLE}.`}
         />
       </Head>
       <Menu activeHref="/schedule" />

--- a/scripts/utils/fetchCompetitions.mjs
+++ b/scripts/utils/fetchCompetitions.mjs
@@ -48,7 +48,7 @@ export default async function fetchCompetitions() {
   }
 
   const res = await nodeFetch(
-    `https://scores.golfbox.dk/Handlers/ScheduleHandler/GetSchedule/CustomerId/${process.env.NEXT_PUBLIC_GOLFBOX_CUSTOMER_ID}/Season/2026/CompetitionId/0/language/2057/`,
+    `https://scores.golfbox.dk/Handlers/ScheduleHandler/GetSchedule/CustomerId/${process.env.NEXT_PUBLIC_GOLFBOX_CUSTOMER_ID}/Season/${new Date().getFullYear()}/CompetitionId/0/language/2057/`,
   );
   if (!res.ok) {
     throw new Error('Failed to fetch comps', res.status, await res.text());


### PR DESCRIPTION
## Summary
- Replace hard-coded `2026` with `new Date().getFullYear()` in the GolfBox API season parameter and the schedule page meta description
- Eliminates the need to manually update the year at the start of each season

## Test plan
- [ ] Verify the schedule page loads correctly and the meta description shows the current year
- [ ] Verify competitions are fetched for the current season

🤖 Generated with [Claude Code](https://claude.com/claude-code)