### PR TITLE
Show winner and final results for finished competitions

### DIFF
--- a/src/competitionDateString.js
+++ b/src/competitionDateString.js
@@ -12,6 +12,7 @@ const DATE_FORMAT = "yyyyMMdd'T'HHmmss";
 export default function competitionDateString(
   competition,
   initialNow = new Date(),
+  { finished } = {},
 ) {
   const utcMidnight = new Date(
     Date.UTC(
@@ -44,7 +45,9 @@ export default function competitionDateString(
 
   let suffix = '';
 
-  if (start - 60 * 60 * 1000 <= utcMidnight && utcMidnight <= end) {
+  if (finished) {
+    suffix = ` — Played ${numberOfDays + 1} rounds`;
+  } else if (start - 60 * 60 * 1000 <= utcMidnight && utcMidnight <= end) {
     // Currently active
     suffix = ` — Playing round ${differenceInDays(utcMidnight, start) + 1} of ${
       numberOfDays + 1

--- a/styles.css
+++ b/styles.css
@@ -150,6 +150,22 @@ a {
   margin-right: 10px;
 }
 
+.winner {
+  margin: 10px 0;
+  border: 2px solid var(--primary);
+  border-radius: 3px;
+}
+
+.winner-heading {
+  margin: 0;
+  padding: 8px 10px;
+  background-color: var(--primary);
+  color: var(--background);
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 14px;
+}
+
 .leaderboard-page,
 .tee-times-page,
 .competitions,


### PR DESCRIPTION
## Summary
- Detect finished competitions via the CompetitionHandler endpoint (`DefaultAction === 'finalresults'`)
- Display the winner's full scorecard prominently at the top of the leaderboard with a "Winner" heading
- Change heading from "Leaderboard" to "Final results" when a competition is finished
- Change date suffix from "Playing round 3 of 3" to "Played 3 rounds"

## Test plan
- [x] Open a finished competition (e.g. CompetitionId 5299728) and verify the winner section appears with their scorecard
- [x] Verify the heading says "Final results" instead of "Leaderboard"
- [x] Verify the date string says "Played 3 rounds" instead of "Playing round 3 of 3"
- [x] Open an in-progress competition and verify no winner section appears and existing behavior is unchanged
- [x] Open an upcoming competition and verify no winner section appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)