### PR TITLE
Add finished status to competitions and display final results

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -223,6 +223,7 @@ export async function getServerSideProps() {
         start: true,
         end: true,
         slug: true,
+        finished: true,
         leaderboardEntries: {
           orderBy: {
             position: 'asc',

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,6 +88,7 @@ model Competition {
   createdAt        DateTime  @default(now())
   updatedAt        DateTime  @default(now())
   visible          Boolean   @default(true)
+  finished         Boolean   @default(false)
   competitionScore PlayerCompetitionScore[]
   leaderboardEntries LeaderboardEntry[]
 }

--- a/src/Leaderboard.js
+++ b/src/Leaderboard.js
@@ -5,15 +5,19 @@ import competitionDateString from './competitionDateString.js';
 import fixParValue from './fixParValue';
 
 export default function Leaderboard({ competition, now }) {
+  const finished = competition.finished;
   return (
     <Link href={`/t/${competition.slug}`}>
       <a className="leaderboard">
-        <div className="leaderboard-legend">Leaderboard</div>
+        <div className="leaderboard-legend">
+          {finished ? 'Final results' : 'Leaderboard'}
+        </div>
         <h4 className="leaderboard-competition-name">
           <span>{competition.name}</span>
         </h4>
         <p className="leaderboard-description">
-          {competition.venue} — {competitionDateString(competition, now)}
+          {competition.venue} —{' '}
+          {competitionDateString(competition, now, { finished })}
         </p>
         <table>
           <thead>
@@ -21,7 +25,7 @@ export default function Leaderboard({ competition, now }) {
               <th>Pos</th>
               <th>Player</th>
               <th>Total</th>
-              <th>Thru</th>
+              {!finished && <th>Thru</th>}
             </tr>
           </thead>
           <tbody>
@@ -43,7 +47,7 @@ export default function Leaderboard({ competition, now }) {
                   <td className={scoreClasses.join(' ')}>
                     {fixParValue(entry.scoreText)}
                   </td>
-                  <td>{entry.hole}</td>
+                  {!finished && <td>{entry.hole}</td>}
                 </tr>
               );
             })}

--- a/src/notifySubscribers.mjs
+++ b/src/notifySubscribers.mjs
@@ -75,6 +75,17 @@ function getLastHoleScore(holeScores) {
   return { toParValue, actualValue, hole, scoreText };
 }
 
+async function fetchIsFinished(competition) {
+  const res = await nodeFetch(
+    `https://scores.golfbox.dk/Handlers/CompetitionHandler/GetCompetition/CompetitionId/${competition.id}/language/2057/`,
+  );
+  if (!res.ok) {
+    return false;
+  }
+  const json = parseJson(await res.text());
+  return json.DefaultAction === 'finalresults';
+}
+
 async function fetchResults(competition) {
   const res = await nodeFetch(
     `https://scores.golfbox.dk/Handlers/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057/`,
@@ -311,6 +322,13 @@ export default async function notifySubscribers() {
     const { finished, started, hotStreakers, leaderboardEntries } =
       await fetchResults(competition);
     await upsertLeaderboard(competition.id, leaderboardEntries);
+    const isFinished = await fetchIsFinished(competition);
+    if (isFinished) {
+      await prisma.competition.update({
+        where: { id: competition.id },
+        data: { finished: true },
+      });
+    }
     for (const result of started) {
       await sendEmail(result, 'started');
     }


### PR DESCRIPTION
## Changes

- Add `finished` boolean field to Competition model in Prisma schema
- Fetch and update `finished` status from Golfbox API in `notifySubscribers`
- Update Leaderboard component to display "Final results" when competition is finished
- Hide "Thru" column and hole information when competition is finished
- Include `finished` field in home page competition query

## Details

This PR adds the ability to mark competitions as finished and update the leaderboard display accordingly. When a competition is marked as finished, the leaderboard shows "Final results" instead of "Leaderboard" and hides the current hole ("Thru") information.