### PR TITLE
Add dark mode target to Happo

### DIFF
--- a/.happo.js
+++ b/.happo.js
@@ -8,6 +8,10 @@ module.exports = {
   apiSecret: process.env.HAPPO_API_SECRET,
   targets: {
     chrome: new RemoteBrowserTarget('chrome', { viewport: '1024x768' }),
+    'chrome-dark': new RemoteBrowserTarget('chrome', {
+      viewport: '1024x768',
+      colorScheme: 'dark',
+    }),
     firefox: new RemoteBrowserTarget('firefox', { viewport: '1024x768' }),
     safari: new RemoteBrowserTarget('safari', { viewport: '1024x768' }),
     iphone: new RemoteBrowserTarget('ios-safari', { viewport: '1024x768' }),


### PR DESCRIPTION
## Summary

- Adds a `chrome-dark` target to the Happo configuration with `colorScheme: 'dark'`
- This enables visual regression testing for the existing dark mode CSS (via `prefers-color-scheme: dark`)

## Test plan

- [ ] Verify Happo CI runs and captures dark mode snapshots under the `chrome-dark` target

🤖 Generated with [Claude Code](https://claude.com/claude-code)