### PR TITLE
Redesign CutInfo as a structured prose block

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -130,6 +130,38 @@ button {
   opacity: 0.7;
 }
 
+.cut-info {
+  margin: 10px 10px 20px;
+  border-left: 5px solid var(--primary);
+  padding-left: 10px;
+}
+
+.cut-info-heading {
+  padding: 0;
+  margin-bottom: 3px;
+  font-weight: 700;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--primary);
+}
+
+.cut-info-body {
+  margin: 0;
+  line-height: 1.5;
+  opacity: 0.7;
+  margin: 0;
+  font-size: 14px;
+  font-weight: normal;
+  padding-bottom: 3px;
+}
+
+.cut-info-body a {
+  color: inherit;
+  text-decoration: underline;
+  font-size: inherit;
+}
+
 a {
   color: var(--primary);
 }


### PR DESCRIPTION
## Summary

- Replaces the old inline cut sentence with a standalone `CutInfo` block element positioned below the competition subtitle
- Shows cut info as soon as the competition has started (not just during/after the cut round), so it is visible between rounds
- Displays three pieces of information in natural prose:
  - **Players inside/made the cut** (bolded, linked to the cut line in the leaderboard)
  - **Projected or actual cut score**
  - **Cut config** (top N players and ties after round R)
- Styled with a red left border and red "CUT INFO" heading, matching the existing `CURRENT CUT LINE` marker color in the leaderboard

## Test plan

- [ ] Check the `ProjectedCutLine` Storybook story — should show projected player count and projected score
- [ ] Check the `FinishedWithCut` Storybook story — should show final player count and actual cut score
- [ ] Check the `Ongoing` story — should show the box with cut config even if cut round hasn't started
- [ ] Verify the "players" link scrolls to the cut line in the leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)