### PR TITLE
Fix competition heading showing 'Upcoming event' after start time

### DIFF
--- a/src/CompetitionPage.js
+++ b/src/CompetitionPage.js
@@ -316,10 +316,10 @@ function getHeading(competition, now, finished) {
   if (finished) {
     return 'Final results';
   }
-  const startOfToday = startOfDay(now);
-  if (competition.start > startOfToday) {
+  if (competition.start > now) {
     return 'Upcoming event';
   }
+  const startOfToday = startOfDay(now);
   if (competition.end >= startOfToday) {
     return 'Leaderboard';
   }


### PR DESCRIPTION
## Summary

- Competitions that have already started were incorrectly showing "Upcoming event" as the heading
- The bug was caused by comparing `competition.start` against `startOfDay(now)` (midnight) instead of the current time, so any competition starting later in the day would still be labeled "Upcoming event"
- Fixed by comparing against `now` directly, so the heading switches to "Leaderboard" as soon as the competition's start time has passed

## Test plan

- [ ] Verify a competition starting today (but in the past) shows "Leaderboard"
- [ ] Verify a competition starting tomorrow still shows "Upcoming event"
- [ ] Verify a finished competition still shows "Final results"

🤖 Generated with [Claude Code](https://claude.com/claude-code)