### PR TITLE
Remove 'Playing' prefix from active round display

### DIFF
--- a/src/competitionDateString.js
+++ b/src/competitionDateString.js
@@ -49,7 +49,7 @@ export default function competitionDateString(
     suffix = ` — Played ${numberOfDays + 1} rounds`;
   } else if (start - 60 * 60 * 1000 <= utcMidnight && utcMidnight <= end) {
     // Currently active
-    suffix = ` — Playing round ${differenceInDays(utcMidnight, start) + 1} of ${
+    suffix = ` — Round ${differenceInDays(utcMidnight, start) + 1} of ${
       numberOfDays + 1
     }`;
   } else {


### PR DESCRIPTION
## Summary
- Changes "Playing round X of Y" to "Round X of Y" during an active competition, keeping the label neutral regardless of round status

## Test plan
- [ ] Verify the date string shows "Round X of Y" during an active competition day
- [ ] Verify "Played X rounds" still shows when the competition is fully finished

🤖 Generated with [Claude Code](https://claude.com/claude-code)