### PR TITLE
Only show winner after the final round is complete

### DIFF
--- a/src/CompetitionPage.js
+++ b/src/CompetitionPage.js
@@ -542,8 +542,21 @@ function MatchPlay({ entries }) {
   );
 }
 
-function isCompetitionFinished(competitionData) {
-  return competitionData && competitionData.DefaultAction === 'finalresults';
+function isCompetitionFinished(competitionData, data, timesData) {
+  if (!competitionData || competitionData.DefaultAction !== 'finalresults') {
+    return false;
+  }
+  if (data && timesData) {
+    const classKey = Object.keys(data.Classes || {})[0];
+    const leaderboardRound =
+      classKey && data.Classes[classKey].Leaderboard.ActiveRoundNumber;
+    const totalRounds =
+      timesData.Rounds && Object.keys(timesData.Rounds).length;
+    if (leaderboardRound && totalRounds && leaderboardRound < totalRounds) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function getWinner(entries) {
@@ -642,7 +655,7 @@ export default function CompetitionPage({
       : [];
 
   const isMatchPlay = entries && entries[0] && entries[0].Players;
-  const finished = isCompetitionFinished(competitionData);
+  const finished = isCompetitionFinished(competitionData, data, timesData);
   const winner = finished ? getWinner(entries) : undefined;
 
   for (const entry of entries || []) {


### PR DESCRIPTION
## Summary
- The winner was being shown prematurely when the GolfBox API returned `DefaultAction='finalresults'` before all rounds were finished
- Added a round-count check: verifies that the leaderboard's `ActiveRoundNumber` equals the total number of rounds before considering the competition finished

## Test plan
- [ ] Verify winner is not shown during an active competition with rounds still in progress
- [ ] Verify winner is shown correctly once all rounds are complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)