### PR TITLE
Remove "required score to make the cut" from post-cut display

### DIFF
--- a/src/CutInfo.js
+++ b/src/CutInfo.js
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import fixParValue from './fixParValue';
 
 function formatProjectedScore(value) {
   const rounded = Math.round(value);
@@ -51,19 +50,6 @@ function getProjectedCutScore(cutConfig, cut, entries, activeRound) {
   return formatProjectedScore(cleanedProjected);
 }
 
-function getActualCutScore(entries, cutPosition) {
-  if (!cutPosition || !entries) {
-    return null;
-  }
-  // The last player who made the cut
-  const cutEntry = entries.find(
-    e => e.Position && e.Position.Actual === cutPosition,
-  );
-  if (!cutEntry || !cutEntry.ResultSum) {
-    return null;
-  }
-  return fixParValue(cutEntry.ResultSum.ToParText);
-}
 
 export default function CutInfo({ data, entries }) {
   if (!data) {
@@ -99,12 +85,9 @@ export default function CutInfo({ data, entries }) {
         .length
     : null;
 
-  let cutScore = null;
-  if (cutDone) {
-    cutScore = getActualCutScore(entries, cut.Position);
-  } else {
-    cutScore = getProjectedCutScore(cutConfig, cut, entries, activeRound);
-  }
+  const cutScore = cutDone
+    ? null
+    : getProjectedCutScore(cutConfig, cut, entries, activeRound);
 
   return (
     <div className="cut-info">
@@ -117,11 +100,8 @@ export default function CutInfo({ data, entries }) {
                 <strong>
                   <a href="#cut">{playersInsideCut} players</a>
                 </strong>{' '}
-                made the cut after round {cut.AfterRound}.{' '}
+                made the cut after round {cut.AfterRound}.
               </>
-            )}
-            {cutScore != null && (
-              <>The score required to make the cut was {cutScore}.</>
             )}
           </>
         ) : (


### PR DESCRIPTION
## Summary
- Removes the "The score required to make the cut was X" sentence from the cut info box after the cut is performed
- The score was incorrectly updating during later rounds because it was based on a player's running total rather than their score at the end of the cut round
- The player count ("X players made the cut after round N") is sufficient and remains unchanged

## Test plan
- [ ] Verify cut info box shows "X players made the cut after round N" after the cut is performed
- [ ] Verify the projected cut score still shows correctly during the cut round
- [ ] Verify no stale score text appears during round 3+

🤖 Generated with [Claude Code](https://claude.com/claude-code)