### PR TITLE
Add "View player profile" button on competition player page

### DIFF
--- a/pages/t/[competitionSlug]/players/[playerId]/index.js
+++ b/pages/t/[competitionSlug]/players/[playerId]/index.js
@@ -126,11 +126,7 @@ function Round({ round, colors, courses, now }) {
   );
 }
 
-export default function CompetitionPlayer({
-  now: nowMs,
-  player,
-  competition,
-}) {
+export default function CompetitionPlayer({ now: nowMs, player, competition }) {
   const now = new Date(nowMs);
   const data = useJsonPData(
     `https://scores.golfbox.dk/Handlers/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057/`,
@@ -170,7 +166,12 @@ export default function CompetitionPlayer({
                 <Link href={`/${player.slug}`} className="player-profile-name">
                   {player.firstName} {player.lastName}
                 </Link>
-                <span className="player-profile-club">{player.clubName}</span>
+                <div className="player-profile-club">{player.clubName}</div>
+                <div className="player-profile-actions">
+                  <Link href={`/${player.slug}`} className="icon-button">
+                    View player profile
+                  </Link>
+                </div>
               </div>
 
               {roundPlayer.ResultSum && (

--- a/styles.css
+++ b/styles.css
@@ -819,6 +819,10 @@ footer {
   text-decoration: none;
 }
 
+.player-profile-actions {
+  margin-top: 10px;
+}
+
 .player-profile-top b {
   font-size: 14px;
   opacity: 0.7;


### PR DESCRIPTION
## Summary
- Adds a "View player profile" button below the club name on the competition player scorecard page
- Links to the player's profile page (`/[slug]`)

## Test plan
- [ ] Visit a competition player scorecard page (e.g. `/t/[competitionSlug]/players/[playerId]`)
- [ ] Confirm the "View player profile" button appears below the club name
- [ ] Confirm clicking it navigates to the player's profile page

🤖 Generated with [Claude Code](https://claude.com/claude-code)