### PR TITLE
Sync stats tab selection to URL via ?stat= query param

### DIFF
--- a/src/PlayerStatsChart.js
+++ b/src/PlayerStatsChart.js
@@ -1,4 +1,6 @@
-import React, { useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import React from 'react';
 
 /**
  * Parse a position string into a numeric value.
@@ -220,7 +222,10 @@ function LineChart({ data, metricKey, lower, formatValue }) {
 }
 
 export default function PlayerStatsChart({ competitionScores }) {
-  const [activeMetric, setActiveMetric] = useState(METRICS[0].key);
+  const router = useRouter();
+  const statParam = router.query.stat;
+  const activeMetric =
+    METRICS.find(m => m.key === statParam)?.key ?? METRICS[0].key;
   const yearlyStats = computeYearlyStats(competitionScores);
 
   if (yearlyStats.length === 0) return null;
@@ -234,7 +239,7 @@ export default function PlayerStatsChart({ competitionScores }) {
         <ul className="tabs stats-tabs">
           {METRICS.map(m => (
             <li key={m.key} className={activeMetric === m.key ? 'tab-selected' : ''}>
-              <button onClick={() => setActiveMetric(m.key)}>{m.label}</button>
+              <Link href={{ query: { ...router.query, stat: m.key } }} scroll={false} shallow>{m.label}</Link>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary

- Stats chart tabs on the player profile page now update the URL with a `?stat=` query parameter (e.g. `?stat=bestScore`)
- Navigating back/forward or sharing a link preserves the selected tab
- Tabs are now `<Link>` elements instead of `<button>` with a click handler, consistent with the season tabs

## Test plan

- [ ] Visit a player profile page and click through the stats tabs — URL should update with `?stat=avgScore`, `?stat=cutPct`, etc.
- [ ] Load a URL with `?stat=bestScore` directly — correct tab should be pre-selected
- [ ] Verify `?season=` param is preserved when switching stat tabs
- [ ] Verify back/forward browser navigation switches tabs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)