### PR TITLE
Hide competitions no longer in fetched schedule

### DIFF
--- a/src/syncData.mjs
+++ b/src/syncData.mjs
@@ -339,7 +339,18 @@ export default async function syncData({ full = true } = {}) {
   const allCompetitions = await prisma.competition.findMany();
   for (const competition of allCompetitions) {
     const newCompetition = competitions.find(c => c.id === competition.id);
-    if (!newCompetition) continue;
+    if (!newCompetition) {
+      if (competition.visible) {
+        console.log(
+          `Hiding competition "${competition.name}" (id=${competition.id}) as it's no longer in the fetched list`,
+        );
+        await prisma.competition.update({
+          where: { id: competition.id },
+          data: { visible: false },
+        });
+      }
+      continue;
+    }
     if (
       newCompetition.name !== competition.name ||
       newCompetition.venue !== competition.venue ||


### PR DESCRIPTION
## Summary

- During sync, competitions that exist in the DB but are absent from the current Golfbox fetch are now marked `visible=false`
- This handles entry-only competitions like "INFINITUM Spring Series 2026 (Entry)" that appear temporarily in Golfbox but shouldn't show in the leaderboard
- Only competitions that are currently `visible=true` are updated, avoiding unnecessary DB writes

## Test plan

- [ ] Verify that a competition removed from the Golfbox schedule is hidden after the next sync
- [ ] Verify that competitions still in the schedule remain visible
- [ ] Verify that already-hidden competitions are not redundantly updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)