### PR TITLE
Improve next event presentation on start page

### DIFF
--- a/src/StartPage.js
+++ b/src/StartPage.js
@@ -70,12 +70,9 @@ ${process.env.NEXT_PUBLIC_INTRO}. Follow your favorite players and get the lates
           <Leaderboard competition={currentCompetition} now={now} />
         )}
         {nextCompetition ? (
-          <>
-            <h3>Next event</h3>
-            <ul>
-              <CompetitionListItem competition={nextCompetition} now={now} />
-            </ul>
-          </>
+          <ul>
+            <CompetitionListItem competition={nextCompetition} now={now} next />
+          </ul>
         ) : null}
         {upcomingCompetitions.length > 0 && (
           <>
@@ -135,14 +132,15 @@ ${process.env.NEXT_PUBLIC_INTRO}. Follow your favorite players and get the lates
   );
 }
 
-function CompetitionListItem({ competition, now, current }) {
+function CompetitionListItem({ competition, now, current, next }) {
   const queryString = now > competition.end ? '?finished=1' : '';
+  const classNames = ['competition-list-item'];
+  if (current) classNames.push('current');
+  if (next) classNames.push('next');
   return (
     <li
       key={competition.id}
-      className={
-        current ? 'competition-list-item current' : 'competition-list-item'
-      }
+      className={classNames.join(' ')}
     >
       <Link href={`/t/${competition.slug}${queryString}`} className="competition">
         <div className="calendar-event">

--- a/styles.css
+++ b/styles.css
@@ -5,8 +5,6 @@
   --primary: #e54e37;
   --primary-light: #f4c7c1;
   --primary-lightest: #ffe6e2;
-  --secondary: #004987;
-  --secondary-light: #6eb4ef;
 
   --medium: #d0d0d0;
   --light: #f0f0f0;
@@ -378,6 +376,38 @@ nav svg {
   color: var(--light);
 }
 
+.competitions li.next .competition {
+  border: 3px solid var(--primary);
+  border-radius: 6px;
+  padding: 10px 12px 14px;
+  column-gap: 16px;
+  align-items: start;
+}
+.competitions li.next .competition::before {
+  content: 'Next event';
+  grid-column: 1 / -1;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--primary);
+  margin-bottom: 12px;
+}
+.competitions li.next .calendar-event {
+  border-color: currentColor;
+  color: inherit;
+}
+.competitions li.next .competition h4 {
+  font-weight: 600;
+  font-size: 18px;
+  white-space: normal;
+  overflow: visible;
+  text-overflow: unset;
+}
+.competitions li.next .competition p {
+  opacity: 0.75;
+}
+
 .leaderboard-page ul li {
   all: unset;
   display: block;
@@ -621,13 +651,13 @@ footer {
   vertical-align: baseline;
 }
 .course-2:before {
-  background-color: var(--secondary);
+  background-color: #004987;
 }
 .course-3:before {
   background-color: var(--primary-light);
 }
 .course-4:before {
-  background-color: var(--secondary-light);
+  background-color: #6eb4ef;
 }
 
 .course-table {


### PR DESCRIPTION
## Summary
- Adds a styled card for the next event with a primary-color border, rounded corners, and an inset "NEXT EVENT" label rendered via CSS `::before`
- Competition name is allowed to wrap inside the card; calendar box aligns to the top of the text with a slightly wider column gap
- Removes unused `--secondary` and `--secondary-light` CSS variables, inlining their values into the course colour indicators where needed

## Test plan
- [ ] Verify the next event card renders correctly on the start page (border, label, layout)
- [ ] Check that the "Future events" and "Past events" lists are unaffected
- [ ] Confirm course colour indicators still display correctly
- [ ] Test in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)