### PR TITLE
Add rounded corners to player photo

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -932,6 +932,8 @@ footer {
 .player-photo-wrap {
   width: 100%;
   aspect-ratio: 1/1;
+  border-radius: 5px;
+  overflow: hidden;
 
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' width='100' height='100'%3E%3Crect width='100' height='100' fill='%23e5e7eb'/%3E%3Ccircle cx='50' cy='35' r='22' fill='%239ca3af'/%3E%3Ccircle cx='50' cy='90' r='35' fill='%239ca3af'/%3E%3C/svg%3E");
   background-size: cover;


### PR DESCRIPTION
## Summary
- Adds `border-radius: 5px` and `overflow: hidden` to `.player-photo-wrap` for rounded corners on player photos

## Test plan
- [ ] Verify player photos appear with rounded corners in the leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)