### PR TITLE
Use default color for next event box border and label

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -377,7 +377,7 @@ nav svg {
 }
 
 .competitions li.next .competition {
-  border: 3px solid var(--primary);
+  border: 3px solid currentColor;
   border-radius: 6px;
   padding: 10px 12px 14px;
   column-gap: 16px;
@@ -390,7 +390,6 @@ nav svg {
   font-weight: 700;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--primary);
   margin-bottom: 12px;
 }
 .competitions li.next .calendar-event {


### PR DESCRIPTION
## Summary
- Removes primary color from the "Next event" box border and label text, using the default text color instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)