### PR TITLE
Fix Leaflet map dark mode styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1236,7 +1236,7 @@ input.ios-switch:checked:after {
 /* Override Leaflet chrome to match site font */
 .tour-map .leaflet-container {
   font-family: Futura, Gill Sans, sans-serif;
-  background: var(--light);
+  background: var(--background);
 }
 
 .tour-map .leaflet-popup-content-wrapper {
@@ -1251,6 +1251,23 @@ input.ios-switch:checked:after {
 }
 
 .tour-map .leaflet-control-zoom a {
+  background: var(--background);
+  color: var(--text);
+  border-color: rgba(var(--text-rgb), 0.2);
+}
+
+.tour-map .leaflet-control-zoom a:hover {
+  background: var(--background);
+  color: var(--text);
+}
+
+.tour-map .leaflet-bar {
+  border-color: rgba(var(--text-rgb), 0.2);
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.25);
+}
+
+.tour-map .leaflet-control-attribution {
+  background: rgba(var(--background-rgb), 0.8);
   color: var(--text);
 }
 


### PR DESCRIPTION
## Summary

- Map container background was using `--light` (#f0f0f0), which has no dark mode override — tile-loading areas showed a stark light background in dark mode
- Zoom control buttons and bar border now use themed CSS variables (`--background`, `--text`, `--text-rgb`) instead of Leaflet's hardcoded white defaults
- Attribution bar now uses semi-transparent `--background-rgb` so it blends into the dark map

## Test plan

- [ ] Visit `/schedule` in dark mode and confirm the map background, zoom buttons, and attribution bar are all dark-themed
- [ ] Confirm light mode appearance is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)