### PR TITLE
Hide cut info box before competition scoring has begun

### DIFF
--- a/src/CutInfo.js
+++ b/src/CutInfo.js
@@ -76,6 +76,15 @@ export default function CutInfo({ data, entries }) {
     return null;
   }
 
+  // In round 1, golfbox sets ActiveRoundNumber=1 before any scoring begins.
+  // Only show once at least one player has actually played a hole.
+  if (activeRound === 1 && entries) {
+    const anyHolesPlayed = entries.some(
+      e => e.ScoringToPar && e.ScoringToPar.HoleValue > 0,
+    );
+    if (!anyHolesPlayed) return null;
+  }
+
   const cutDone = cut.IsPerformed || activeRound > cut.AfterRound;
 
   const playersInsideCut = cutDone


### PR DESCRIPTION
## Summary

- Golfbox pre-sets `ActiveRoundNumber=1` and `Cut.AfterRound` before any play begins, so the existing `!activeRound` guard was not enough to suppress the cut info box
- Added a check in round 1: only show the box once at least one entry has a positive `HoleValue` (the API uses large negative sentinel values when no holes have been played)

## Test plan

- [ ] Visit a competition starting in the future — cut info box should not appear
- [ ] Visit a competition in round 1 with active scoring — cut info box should appear normally
- [ ] Verify post-cut and finished competitions still display cut info correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)