### PR TITLE
Hide projected cut score until a round is 75% complete

### DIFF
--- a/src/CutInfo.js
+++ b/src/CutInfo.js
@@ -40,6 +40,11 @@ function getProjectedCutScore(cutConfig, cut, entries, activeRound) {
   if (!holesPlayedByField || !totalFieldHoles) {
     return null;
   }
+  // Only show projected cut once at least one round is 75% done.
+  // holesPlayedByField at this point is holes played in the current round only.
+  if (activeRound === 1 && holesPlayedByField < entries.length * 18 * 0.75) {
+    return null;
+  }
   holesPlayedByField += (activeRound - 1) * 18 * entries.length;
   const fieldCompletionRatio = holesPlayedByField / totalFieldHoles;
   const projected = currentScore + currentScore * fieldCompletionRatio;


### PR DESCRIPTION
## Summary

- Projected cut score is now suppressed until at least one round is 75% complete
- In round 1, the score only appears once 75% of the field has played their holes (≥ 13.5 holes per player on average)
- In round 2+, the condition is automatically satisfied since round 1 is already fully complete

## Test plan

- [ ] Verify projected cut score does not appear early in round 1 (< 75% field completion)
- [ ] Verify projected cut score appears once round 1 crosses the 75% threshold
- [ ] Verify projected cut score still appears normally in round 2 and beyond

🤖 Generated with [Claude Code](https://claude.com/claude-code)