### PR TITLE
Hide projected cut score in round 1 until 75% of holes are played

### DIFF
--- a/src/CutInfo.js
+++ b/src/CutInfo.js
@@ -65,6 +65,12 @@ function getProjectedCutScore(cutConfig, cut, entries, activeRound) {
   if (!holesPlayedByField || !totalFieldHoles) {
     return null;
   }
+
+  // During round 1, don't show projected cut until 75% of round 1 holes are played
+  if (activeRound === 1 && holesPlayedByField / (entries.length * 18) < 0.75) {
+    return null;
+  }
+
   const fieldCompletionRatio = holesPlayedByField / totalFieldHoles;
   const projected = currentScore + currentScore * fieldCompletionRatio;
 


### PR DESCRIPTION
## Summary
- During round 1, `getProjectedCutScore` now returns `null` if fewer than 75% of round 1 holes have been played across the field
- The rest of the cut info (players currently inside the cut line) continues to show as normal — only the projected score text is suppressed

## Test plan
- [ ] Verify projected cut score is hidden early in round 1 (< 75% field completion)
- [ ] Verify projected cut score appears once ≥ 75% of round 1 holes are played
- [ ] Verify no change in behaviour for round 2 and beyond

🤖 Generated with [Claude Code](https://claude.com/claude-code)