### PR TITLE
Add AI attribution note to report pages

### DIFF
--- a/pages/reports/[slug].js
+++ b/pages/reports/[slug].js
@@ -120,6 +120,13 @@ export default function ReportPage({ report }) {
           </aside>
         )}
 
+        <p className="report-ai-note">
+          This report was written with the help of an{' '}
+          <a href="https://anthropic.com" target="_blank" rel="noopener noreferrer">
+            Anthropic
+          </a>{' '}
+          LLM.
+        </p>
         <p className="report-footer">
           <Link href="/">← Back to home</Link>
         </p>

--- a/styles.css
+++ b/styles.css
@@ -1983,3 +1983,9 @@ h2.player-big-name {
   color: inherit;
   text-decoration: underline;
 }
+
+.report-ai-note {
+  margin-top: 8px;
+  font-size: 12px;
+  opacity: 0.5;
+}


### PR DESCRIPTION
## Summary

- Adds a note at the bottom of each tournament report page: "This report was written with the help of an [Anthropic](https://anthropic.com) LLM."
- Note appears above the "← Back to home" link, styled small and muted (12px, 50% opacity)

## Test plan

- [ ] Visit any report page (e.g. `/reports/golfstar-winter-series-dunes-2026`) and verify the note appears above the back link
- [ ] Verify "Anthropic" links to https://anthropic.com and opens in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)