### PR TITLE
Highlight extraordinary rounds in tournament reports

### DIFF
--- a/src/reports/golfstar-winter-series-dunes-2026.json
+++ b/src/reports/golfstar-winter-series-dunes-2026.json
@@ -6,9 +6,9 @@
   "startDate": "2026-02-14T00:00:00.000Z",
   "endDate": "2026-02-16T00:00:00.000Z",
   "slug": "golfstar-winter-series-dunes-2026",
-  "headline": "Tidén Storms to Four-Shot Triumph at Empordá",
-  "blurb": "Sweden's Albin Tidén delivered a commanding wire-to-wire performance at the GolfStar Winter Series Dunes, finishing at 15 under par to claim a comfortable victory in Spain.",
-  "body": "Albin Tidén produced a stunning display at Empordá Golf Club to win the GolfStar Winter Series Dunes by four clear shots, carding a three-round total of 15 under par. The Romeleåsens Golfklubb member was in imperious form throughout the week, pulling away from a packed chasing group to seal a thoroughly deserved title on the Cutter & Buck tour.\n\nFredrik Lindblom and David Lundgren of Vasatorps Golfklubb shared second place at 11 under par, four strokes adrift of the champion. Dutchman Thom Hoetmer finished alone in fourth at 10 under, while Charlie Lindh of Araslöv Golf & Resort rounded out the top five on nine under. Despite solid performances from the runners-up, none could mount a serious late challenge as Tidén held firm throughout the final round.\n\nThe cut fell at one under par, trimming a 137-strong field down to 51 players for the weekend rounds. The demanding dunes layout at Empordá clearly rewarded precision and course management, with fewer than 40 percent of the field surviving to play all three rounds.\n\nFor Tidén, the four-shot margin of victory underlines his growing confidence on the Nordic tour circuit. With the winter swing in full flow across southern Europe, this result marks him out as a player to watch as the 2026 season develops.",
+  "headline": "Tidén Storms to Four-Shot Victory at GolfStar Winter Series Dunes",
+  "blurb": "Albin Tidén pulled away from the field at Empordá Golf Club, finishing at 15-under to claim a commanding win on the Cutter & Buck tour's stop in Spain.",
+  "body": "Albin Tidén of Romeleåsens Golfklubb delivered a masterclass over three rounds at Empordá Golf Club, posting a 15-under-par total to win the GolfStar Winter Series Dunes by four clear shots. The Swede was in imperious form from start to finish, building a lead that no rival could seriously threaten down the stretch.\n\nFredrik Lindblom and David Lundgren shared second place at 11-under, with Lundgren's spectacular second-round 62 proving the standout individual performance of the week. That blistering effort vaulted Lundgren up the leaderboard, though it ultimately was not enough to catch the runaway leader. Dutch player Thom Hoetmer finished alone in fourth at 10-under, while Charlie Lindh of Araslöv Golf & Resort rounded out the top five at nine-under.\n\nThe cut fell at one-under par, trimming a 137-player field down to 51 for the final round. The demanding Dunes course at Empordá extracted a heavy toll, with more than 60 percent of the field heading home early — a testament to the challenging conditions along Spain's Costa Brava.\n\nFor Tidén, the four-stroke margin underscored his consistency across all three days. While others produced flashes of brilliance, nobody could match his relentless scoring over 54 holes. It was a statement performance that positions him as one to watch as the Cutter & Buck tour season progresses.",
   "winnerName": "Albin Tidén",
   "winnerPlayerId": "981005-006",
   "winnerPlayerSlug": "albin-tiden",
@@ -70,5 +70,5 @@
       }
     ]
   },
-  "createdAt": "2026-02-26T21:04:04.481Z"
+  "createdAt": "2026-02-27T10:36:45.508Z"
 }

--- a/src/reports/golfstar-winter-series-forest-2026.json
+++ b/src/reports/golfstar-winter-series-forest-2026.json
@@ -6,9 +6,9 @@
   "startDate": "2026-02-18T00:00:00.000Z",
   "endDate": "2026-02-20T00:00:00.000Z",
   "slug": "golfstar-winter-series-forest-2026",
-  "headline": "Eriksson Seizes Four-Shot Win at Empordá Forest Event",
-  "blurb": "Martin Eriksson delivered a commanding performance at Empordá Golf Club, finishing at 16 under par to claim the GolfStar Winter Series Forest title by four strokes.",
-  "body": "Martin Eriksson of Kårsta Golfklubb produced a masterful three-day display at Empordá Golf Club, posting a 16-under-par total to capture the GolfStar Winter Series Forest title with daylight between himself and the chasing pack. The Swede's four-shot margin of victory underlined just how in control he was from start to finish across the scenic Spanish layout.\n\nDavid Lundgren (Kristianstads Golfklubb) and Oliver Gillberg (Askersunds Golfklubb) shared second place at 12 under par, both putting together solid weeks but ultimately unable to mount a serious challenge to Eriksson's relentless scoring. Charlie Lindh of Araslöv Golf & Resort and Upsala Golfklubb's David Nyfjäll rounded out the top five at 11 under, further evidence of the quality on show in the upper reaches of the leaderboard.\n\nThe cut fell at one under par, trimming a 138-player field down to 51 competitors for the final round. That demanding threshold meant more than 60 percent of the field headed home early, highlighting the competitive depth on the Cutter & Buck tour's winter swing.\n\nEriksson's emphatic victory marks him as a player to watch as the Nordic tour's 2026 season gathers momentum. With performances of this calibre on challenging European venues, the Kårsta man will carry serious confidence into the coming months.",
+  "headline": "Eriksson Dominates GolfStar Winter Series Forest by Four Shots",
+  "blurb": "Martin Eriksson's blistering opening 62 set the tone as he powered to a commanding four-stroke victory at Empordá Golf Club, finishing at 16 under par.",
+  "body": "Martin Eriksson delivered a masterclass at Empordá Golf Club this week, capturing the GolfStar Winter Series Forest title on the Cutter & Buck tour with a commanding 16-under-par total, four shots clear of the chasing pack.\n\nThe Kårsta Golfklubb professional set the tournament alight from the very first round, carding an extraordinary 62 to seize early control. It was not the only exceptional scorecard of the opening day — Charlie Lindh of Araslöv Golf & Resort fired a superb 63 — but Eriksson's effort proved the spark for a wire-to-wire display of sustained excellence over three rounds in southern Spain.\n\nDavid Lundgren of Kristianstads Golfklubb and Askersund's Oliver Gillberg shared second place at 12 under par, while Lindh and David Nyfjäll of Upsala Golfklubb rounded out the top five at 11 under. Despite their strong efforts, none could mount a serious challenge to the runaway leader.\n\nThe cut fell at one under par, trimming a 138-player field down to 51 competitors for the final round. The demanding threshold underscored the quality of play across the board, but this week ultimately belonged to Eriksson, whose opening fireworks and relentless consistency earned him a thoroughly deserved victory on the Nordic tour.",
   "winnerName": "Martin Eriksson",
   "winnerPlayerId": "920313-022",
   "winnerPlayerSlug": "martin-eriksson",
@@ -70,5 +70,5 @@
       }
     ]
   },
-  "createdAt": "2026-02-26T21:05:31.413Z"
+  "createdAt": "2026-02-27T10:36:11.394Z"
 }

--- a/src/reports/infinitum-ecco-masters---golfbox-tournament-no-1000000.json
+++ b/src/reports/infinitum-ecco-masters---golfbox-tournament-no-1000000.json
@@ -6,9 +6,9 @@
   "startDate": "2026-02-23T00:00:00.000Z",
   "endDate": "2026-02-25T00:00:00.000Z",
   "slug": "infinitum-ecco-masters---golfbox-tournament-no-1000000",
-  "headline": "Simonsen Cruises to Dominant INFINITUM ECCO Masters Victory",
-  "blurb": "Denmark's Martin Leth Simonsen delivered a stunning 23-under-par performance in Spain, pulling clear of Finland's Matias Honkala to claim the milestone GolfBox Tournament no. 1,000,000.",
-  "body": "Martin Leth Simonsen produced a masterclass at Infinitum Golf in Spain, romping to a four-shot victory at the INFINITUM ECCO Masters with a commanding total of 23 under par. The Aalborg Golf Klub member was in imperious form across all three rounds from February 23–25, leaving the rest of the 153-player field trailing in his wake.\n\nFinland's Matias Honkala of Nevas Golf emerged as the closest challenger, finishing at 19 under par in solo second place. While Honkala's score would have been enough to win many tournaments on the Cutter & Buck tour, he simply had no answer for Simonsen's relentless brilliance. A cluster of three players — Marcus Svensson of Halmstad Golfklubb, Jerry Ji, and Kasper Nyland — shared third place at 13 under, a full ten shots behind the champion.\n\nThe cut fell at two under par, with 56 of the 153 starters advancing to the final round. That demanding threshold underlined the quality of the field, though nobody could match the extraordinary standard set by Simonsen at the top of the leaderboard.\n\nThis landmark event — officially GolfBox Tournament no. 1,000,000 — will be remembered for a complete and authoritative display from Simonsen. His wire-to-wire dominance and the considerable gap between himself and the chasing pack mark this as one of the most emphatic performances of the Nordic tour season so far.",
+  "headline": "Simonsen Cruises to INFINITUM ECCO Masters Title With Record 60",
+  "blurb": "Martin Leth Simonsen produced a stunning third-round 60 to pull away from the field and claim a four-shot victory at Infinitum Golf in Spain.",
+  "body": "Martin Leth Simonsen delivered a masterclass at the INFINITUM ECCO Masters, finishing at 23 under par to claim a commanding four-shot victory over Finland's Matias Honkala at Infinitum Golf in Spain. The Aalborg Golf Klub member was in imperious form throughout the three-day event, capping his performance with a breathtaking round of 60 on the final day — a score that left the rest of the field with no answer.\n\nHonkala had set the early tone with a spectacular opening-round 61, signalling his intent from the outset. But while the Finn remained in contention at 19 under par, Simonsen's historic final round proved the decisive blow. Jonas Baumgartner (62) and Jean Bekirian (63) also lit up the opening day with extraordinary scoring, while amateur Lauri Rosendahl fired a brilliant 62 in the final round to underline the quality on show.\n\nA three-way tie for third at 13 under par saw Marcus Svensson, Jerry Ji, and Kasper Nyland share the podium places, ten shots adrift of the champion — highlighting just how far clear the top two pulled from the chasing pack.\n\nThe cut fell at two under par in a competitive field of 153 players, with only 56 advancing to the final round. The INFINITUM ECCO Masters, notably the one-millionth tournament hosted on the GolfBox platform, will be remembered above all for Simonsen's phenomenal closing 60 — a round that turned a tight contest into a coronation.",
   "winnerName": "Martin Leth Simonsen",
   "winnerPlayerId": "2-3476",
   "winnerPlayerSlug": "martin-leth-simonsen",
@@ -70,5 +70,5 @@
       }
     ]
   },
-  "createdAt": "2026-02-27T10:19:12.367Z"
+  "createdAt": "2026-02-27T10:35:10.860Z"
 }


### PR DESCRIPTION
## Summary

- Extracts per-round gross scores from the GolfBox leaderboard API (`entry.Rounds[roundKey].HoleScores['H-TOTAL'].Score`)
- Identifies any rounds with a gross score ≤ 63 and surfaces them to the Claude prompt
- The AI is prompted that these extraordinary rounds could be mentioned in the article
- Logs extraordinary rounds to the console during script execution

## Test plan

- [ ] Run `writeReport.mjs` on a tournament that has a round of 63 or better and verify it appears in the generated article body
- [ ] Run on a tournament with no extraordinary rounds and verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)