### PR TITLE
Style past events differently on schedule page

### DIFF
--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -63,12 +63,17 @@ export default function SchedulePage({ competitions, now: nowMs }) {
 
 function CompetitionItem({ competition, now, current }) {
   const queryString = now > competition.end ? '?finished=1' : '';
+  const past = !current && now > competition.end;
   return (
     <tr
       key={competition.id}
-      className={
-        current ? 'competition-list-item current' : 'competition-list-item'
-      }
+      className={[
+        'competition-list-item',
+        current ? 'current' : '',
+        past ? 'past' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
     >
       <td>
         <Link href={`/t/${competition.slug}${queryString}`}>

--- a/styles.css
+++ b/styles.css
@@ -1219,6 +1219,15 @@ input.ios-switch:checked:after {
   opacity: 0.7;
 }
 
+.competition-list-item.past {
+  opacity: 0.5;
+}
+
+.competition-list-item.past a {
+  text-decoration: line-through;
+  text-decoration-color: currentColor;
+}
+
 .tour-map-wrapper {
   max-width: 600px;
   margin: 0 auto 24px;


### PR DESCRIPTION
## Summary

- Adds a `past` CSS class to schedule rows where the competition has ended
- Dims past events with `opacity: 0.5` so they visually recede
- Applies a `line-through` decoration to the event link, making it clear the tournament has been played

## Test plan

- [ ] Visit the `/schedule` page and verify past events appear dimmed and struck through
- [ ] Verify ongoing events still get the `current` highlight
- [ ] Verify upcoming events appear at full opacity with no decoration

🤖 Generated with [Claude Code](https://claude.com/claude-code)