### PR TITLE
Add year tabs to schedule page

### DIFF
--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -1,4 +1,4 @@
-import { format, startOfDay, startOfYear } from 'date-fns';
+import { format, startOfDay } from 'date-fns';
 import Link from 'next/link';
 import Head from 'next/head';
 import React, { useState, useEffect } from 'react';
@@ -8,7 +8,12 @@ import ensureDates from '../src/ensureDates.js';
 import prisma from '../src/prisma';
 import locations from '../src/locations.json';
 
-export default function SchedulePage({ competitions, now: nowMs }) {
+export default function SchedulePage({
+  competitions,
+  years,
+  selectedYear,
+  now: nowMs,
+}) {
   competitions.forEach(ensureDates);
   const now = startOfDay(new Date(nowMs));
   const currentCompetition = competitions.find(
@@ -25,7 +30,9 @@ export default function SchedulePage({ competitions, now: nowMs }) {
         <title>Schedule</title>
         <meta
           name="description"
-          content={`Full schedule for the ${new Date().getFullYear()} season of ${process.env.NEXT_PUBLIC_INTRO_TITLE}.`}
+          content={`Full schedule for the ${new Date().getFullYear()} season of ${
+            process.env.NEXT_PUBLIC_INTRO_TITLE
+          }.`}
         />
       </Head>
       <Menu activeHref="/schedule" />
@@ -33,9 +40,27 @@ export default function SchedulePage({ competitions, now: nowMs }) {
         <h2>Tour schedule</h2>
         <div className="tour-map-wrapper">
           {TourMap && (
-            <TourMap competitions={competitions} locations={locations} now={now} />
+            <TourMap
+              competitions={competitions}
+              locations={locations}
+              now={now}
+            />
           )}
         </div>
+        {years.length > 1 && (
+          <div className="page-margin">
+            <ul className="tabs">
+              {years.map(year => (
+                <li
+                  key={year}
+                  className={selectedYear === year ? 'tab-selected' : ''}
+                >
+                  <Link href={`/schedule?year=${year}`}>{year}</Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
         <table className="results-table page-margin">
           <thead>
             <tr>
@@ -51,6 +76,7 @@ export default function SchedulePage({ competitions, now: nowMs }) {
                   competition={c}
                   now={now}
                   current={currentCompetition && currentCompetition.id === c.id}
+                  previousYear={selectedYear < new Date(nowMs).getFullYear()}
                 />
               ))}
             </tbody>
@@ -61,7 +87,7 @@ export default function SchedulePage({ competitions, now: nowMs }) {
   );
 }
 
-function CompetitionItem({ competition, now, current }) {
+function CompetitionItem({ competition, now, current, previousYear }) {
   const queryString = now > competition.end ? '?finished=1' : '';
   const past = !current && now > competition.end;
   return (
@@ -71,6 +97,7 @@ function CompetitionItem({ competition, now, current }) {
         'competition-list-item',
         current ? 'current' : '',
         past ? 'past' : '',
+        previousYear ? 'previous-year' : '',
       ]
         .filter(Boolean)
         .join(' ')}
@@ -90,11 +117,29 @@ function CompetitionItem({ competition, now, current }) {
   );
 }
 
-export async function getServerSideProps() {
+export async function getServerSideProps({ query }) {
   const now = Date.now();
+  const currentYear = new Date(now).getFullYear();
+  const selectedYear = query.year ? parseInt(query.year, 10) : currentYear;
+
+  const allCompetitions = await prisma.competition.findMany({
+    select: { start: true },
+    orderBy: { start: 'asc' },
+  });
+  const yearsSet = new Set(
+    allCompetitions.map(c => new Date(c.start).getFullYear()),
+  );
+  const years = [...yearsSet].sort((a, b) => a - b);
+
+  const yearStart = new Date(selectedYear, 0, 1);
+  const yearEnd = new Date(selectedYear + 1, 0, 1);
+
   const competitions = await prisma.competition.findMany({
     orderBy: { end: 'asc' },
-    where: { visible: true, start: { gte: startOfYear(new Date(now)) } },
+    where: {
+      visible: true,
+      start: { gte: yearStart, lt: yearEnd },
+    },
     select: {
       id: true,
       name: true,
@@ -108,5 +153,5 @@ export async function getServerSideProps() {
     c.start = c.start.getTime();
     c.end = c.end.getTime();
   }
-  return { props: { competitions, now } };
+  return { props: { competitions, years, selectedYear, now } };
 }

--- a/scripts/show-hidden-competitions.mjs
+++ b/scripts/show-hidden-competitions.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import prisma from '../src/prisma.mjs';
+
+const updated = await prisma.competition.updateMany({
+  where: {
+    visible: false,
+    NOT: [
+      { name: { contains: '(Entry)' } },
+      { name: { contains: 'FINAL 5 PLAY-OFF SERIES' } },
+    ],
+  },
+  data: { visible: true },
+});
+
+console.log(`Made ${updated.count} competitions visible`);
+
+await prisma.$disconnect();

--- a/src/syncData.mjs
+++ b/src/syncData.mjs
@@ -367,11 +367,19 @@ export default async function syncData({ full = true } = {}) {
     });
   }, clearOomItems);
 
+  const fetchedYear =
+    competitions.length > 0
+      ? competitions[0].start.getFullYear()
+      : new Date().getFullYear();
+
   const allCompetitions = await prisma.competition.findMany();
   for (const competition of allCompetitions) {
     const newCompetition = competitions.find(c => c.id === competition.id);
     if (!newCompetition) {
-      if (competition.visible) {
+      if (
+        competition.visible &&
+        competition.start.getFullYear() === fetchedYear
+      ) {
         console.log(
           `Hiding competition "${competition.name}" (id=${competition.id}) as it's no longer in the fetched list`,
         );

--- a/styles.css
+++ b/styles.css
@@ -1219,6 +1219,7 @@ input.ios-switch:checked:after {
   opacity: 0.7;
 }
 
+
 .competition-list-item.past {
   opacity: 0.5;
 }
@@ -1226,6 +1227,15 @@ input.ios-switch:checked:after {
 .competition-list-item.past a {
   text-decoration: line-through;
   text-decoration-color: currentColor;
+}
+
+.competition-list-item.previous-year {
+  opacity: 1;
+}
+
+.competition-list-item.previous-year a {
+  color: inherit;
+  text-decoration: none;
 }
 
 .tour-map-wrapper {


### PR DESCRIPTION
## Summary

- Schedule page now shows year tabs to filter events by season, defaulting to the current year
- Previous-year competitions are styled with plain text-colored links (no strikethrough/opacity), distinct from current-year past events
- `syncData` no longer hides competitions from past years when syncing the current season
- Includes a one-off script (`scripts/show-hidden-competitions.mjs`) used to restore visibility of past competitions (already run in production)

## Test plan

- [ ] Visit `/schedule` — should show current year's events as before
- [ ] If multiple years exist in the DB, year tabs appear between the map and the table
- [ ] Clicking a past year tab shows that year's competitions with plain-colored links
- [ ] Current year past events still show with opacity + strikethrough
- [ ] Verify sync job no longer hides past-year competitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)