### PR TITLE
Improve alert styling in dark mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -200,6 +200,13 @@ a {
   margin-left: 10px;
   margin-right: 10px;
 }
+@media (prefers-color-scheme: dark) {
+  .alert {
+    background-color: rgba(229, 78, 55, 0.15);
+    border-color: rgba(229, 78, 55, 0.4);
+    color: var(--text);
+  }
+}
 
 .winner {
   margin: 10px 0;


### PR DESCRIPTION
## Summary

- Adds a `@media (prefers-color-scheme: dark)` override for `.alert`
- Uses a low-opacity primary red tint for background instead of the light pink (`--primary-lightest`) that looks out of place on dark backgrounds
- Updates text color to `--text` (`#f0f0f0`) so it's readable in dark mode

## Test plan

- [ ] Visit a page with an alert (e.g. `/t/danish-pga-championship-not-ngl-2026`) in dark mode and verify the alert blends naturally with the dark background

🤖 Generated with [Claude Code](https://claude.com/claude-code)