### PR TITLE
Redesign course page with vertical layout and hole illustrations

### DIFF
--- a/pages/t/[competitionSlug]/courses/[courseId]/index.js
+++ b/pages/t/[competitionSlug]/courses/[courseId]/index.js
@@ -6,6 +6,21 @@ import LoadingSkeleton from '../../../../../src/LoadingSkeleton';
 import Menu from '../../../../../src/Menu';
 import prisma from '../../../../../src/prisma';
 
+function HoleIllustration({ length, maxLength }) {
+  const pct = Math.max(15, (length / maxLength) * 100);
+  return (
+    <div className="hole-visual" style={{ '--hole-pct': `${pct}%` }}>
+      <div className="hole-tee" />
+      <div className="hole-fairway" />
+      <div className="hole-green">
+        <div className="hole-flagpole" />
+        <div className="hole-flag" />
+        <div className="hole-cup" />
+      </div>
+    </div>
+  );
+}
+
 export default function Course({ competition }) {
   const router = useRouter();
   const { courseId } = router.query;
@@ -17,6 +32,32 @@ export default function Course({ competition }) {
   const loading = !data;
   const course = data && data.Courses[`C${courseId}`];
   const venue = data && data.CompetitionData.Venue;
+
+  const holes = course
+    ? Object.entries(course.Holes)
+        .filter(([key]) => /^H\d+$/.test(key))
+        .map(([key, hole]) => {
+          const tee = Object.values(hole.Tees)[0];
+          return {
+            key,
+            number: key.replace(/^H/, ''),
+            length: tee.Length,
+            par: tee.Par,
+          };
+        })
+        .sort((a, b) => parseInt(a.number) - parseInt(b.number))
+    : [];
+
+  const maxLength = holes.length ? Math.max(...holes.map(h => h.length)) : 1;
+  const totalLength = holes.reduce((sum, h) => sum + h.length, 0);
+  const totalPar = holes.reduce((sum, h) => sum + h.par, 0);
+  const frontNine = holes.slice(0, 9);
+  const backNine = holes.slice(9);
+  const frontLength = frontNine.reduce((sum, h) => sum + h.length, 0);
+  const backLength = backNine.reduce((sum, h) => sum + h.length, 0);
+  const frontPar = frontNine.reduce((sum, h) => sum + h.par, 0);
+  const backPar = backNine.reduce((sum, h) => sum + h.par, 0);
+
   return (
     <div>
       <Menu activeHref="/leaderboard" />
@@ -28,24 +69,40 @@ export default function Course({ competition }) {
             <h2>
               {venue.Name} – {course.Name}
             </h2>
-            <div className="course-table">
-              <div className="course-item">
-                <span>Hole</span>
-                <span>Len(m)</span>
-                <span>Par</span>
-              </div>
-
-              {Object.keys(course.Holes).map(holeKey => {
-                const hole = course.Holes[holeKey];
-                const tee = Object.values(hole.Tees)[0];
-                return (
-                  <div key={holeKey} className="course-item">
-                    <span>{holeKey.replace(/^H-?/, '')}</span>
-                    <span>{tee.Length}</span>
-                    <span>{tee.Par}</span>
+            <div className="hole-list">
+              {holes.map((hole, i) => (
+                <React.Fragment key={hole.key}>
+                  <div className="hole-row">
+                    <span className="hole-num">{hole.number}</span>
+                    <HoleIllustration length={hole.length} maxLength={maxLength} />
+                    <span className="hole-len">{hole.length}m</span>
+                    <span className="hole-par">Par {hole.par}</span>
                   </div>
-                );
-              })}
+                  {i === 8 && backNine.length > 0 && (
+                    <div className="hole-subtotal">
+                      <span className="hole-subtotal-label">Out</span>
+                      <span className="hole-subtotal-len">{frontLength}m</span>
+                      <span className="hole-subtotal-par">Par {frontPar}</span>
+                    </div>
+                  )}
+                </React.Fragment>
+              ))}
+              {holes.length > 0 && (
+                <>
+                  {backNine.length > 0 && (
+                    <div className="hole-subtotal">
+                      <span className="hole-subtotal-label">In</span>
+                      <span className="hole-subtotal-len">{backLength}m</span>
+                      <span className="hole-subtotal-par">Par {backPar}</span>
+                    </div>
+                  )}
+                  <div className="hole-subtotal hole-subtotal--total">
+                    <span className="hole-subtotal-label">Total</span>
+                    <span className="hole-subtotal-len">{totalLength}m</span>
+                    <span className="hole-subtotal-par">Par {totalPar}</span>
+                  </div>
+                </>
+              )}
             </div>
           </>
         )}

--- a/styles.css
+++ b/styles.css
@@ -687,7 +687,6 @@ footer {
 .hole-visual {
   position: relative;
   height: 28px;
-  background: #2d5c20;
   border-radius: 3px;
   overflow: visible;
 }

--- a/styles.css
+++ b/styles.css
@@ -225,13 +225,13 @@ a {
 .profile,
 .schedule,
 .sign-in,
+.course,
 nav {
   max-width: 600px;
   margin: 0 auto;
 }
 
-.player-profile,
-.course {
+.player-profile {
   max-width: 710px;
   margin: 0 auto;
 }
@@ -659,53 +659,151 @@ footer {
   background-color: #6eb4ef;
 }
 
-.course-table {
-  padding: 10px;
-  width: 100%;
-  overflow: auto;
-}
 .course {
   margin-bottom: 15px;
 }
 
-.course-table {
-  color: var(--text);
+.hole-list {
+  max-width: 500px;
+  padding: 8px 0;
+}
+
+.hole-row {
+  display: grid;
+  grid-template-columns: 22px 1fr 52px 52px;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+.hole-num {
   font-size: 12px;
-  opacity: 0.8;
+  font-weight: 600;
+  color: var(--text);
+  opacity: 0.5;
+  text-align: right;
 }
 
-.course-table {
-  display: grid;
-  grid-template-columns: auto repeat(21, 1fr);
-  column-gap: 5px;
-}
-.course-item {
-  display: grid;
-  grid-template-columns: 1fr;
-  row-gap: 5px;
-  text-align: center;
-}
-.course-item > *:first-child {
-  font-weight: bold;
-}
-.course-item:first-child {
-  text-align: left;
-  font-weight: bold;
-  white-space: nowrap;
+.hole-visual {
+  position: relative;
+  height: 28px;
+  background: #2d5c20;
+  border-radius: 3px;
+  overflow: visible;
 }
 
-@media (max-width: 900px) {
-  .course-table {
-    grid-template-columns: 1fr;
-    row-gap: 10px;
-    max-width: 200px;
-    margin: 0 auto;
-  }
-  .course-item {
-    grid-template-columns: 1fr 1fr 1fr;
-    column-gap: 5px;
-    text-align: left;
-  }
+.hole-tee {
+  position: absolute;
+  left: 3px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 10px;
+  height: 18px;
+  background: #5cb870;
+  border-radius: 2px;
+  z-index: 2;
+}
+
+.hole-fairway {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: calc(var(--hole-pct) - 14px);
+  height: 10px;
+  background: #4a9e5c;
+  z-index: 1;
+}
+
+.hole-green {
+  position: absolute;
+  left: var(--hole-pct);
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 22px;
+  height: 22px;
+  background: #6ed476;
+  border-radius: 50%;
+  z-index: 3;
+}
+
+.hole-flagpole {
+  position: absolute;
+  left: calc(50% - 0.5px);
+  top: 10%;
+  width: 1px;
+  height: 40%;
+  background: #bbb;
+}
+
+.hole-flag {
+  position: absolute;
+  left: 50%;
+  top: 10%;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 3.5px 0 3.5px 7px;
+  border-color: transparent transparent transparent #e54e37;
+}
+
+.hole-cup {
+  position: absolute;
+  top: 52%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 6px;
+  height: 6px;
+  background: #1a3a10;
+  border-radius: 50%;
+}
+
+.hole-len {
+  font-size: 12px;
+  color: var(--text);
+  opacity: 0.7;
+  text-align: right;
+}
+
+.hole-par {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  text-align: right;
+}
+
+.hole-subtotal {
+  display: grid;
+  grid-template-columns: 22px 1fr 52px 52px;
+  gap: 8px;
+  align-items: center;
+  padding: 4px 0;
+  font-size: 12px;
+  color: var(--text);
+  opacity: 0.6;
+  border-top: 1px solid rgba(var(--text-rgb), 0.15);
+}
+
+.hole-subtotal-label {
+  grid-column: 1;
+  font-weight: 600;
+  text-align: right;
+}
+
+.hole-subtotal-len {
+  grid-column: 3;
+  text-align: right;
+}
+
+.hole-subtotal-par {
+  grid-column: 4;
+  text-align: right;
+}
+
+.hole-subtotal--total {
+  font-weight: 700;
+  opacity: 0.9;
+  border-top: 2px solid rgba(var(--text-rgb), 0.25);
 }
 
 .leaderboard-page .round-start-time {
@@ -1218,7 +1316,6 @@ input.ios-switch:checked:after {
   display: block;
   opacity: 0.7;
 }
-
 
 .competition-list-item.past {
   opacity: 0.5;


### PR DESCRIPTION
## Summary

- Replaces the horizontal scrolling hole table with a vertical list — one row per hole
- Each row includes a proportional top-down golf hole illustration (tee box → fairway → green with flag) so you can see at a glance how long each hole is relative to the others
- Tee box and green are fixed-size CSS elements (no stretching); only the fairway bar scales with hole length
- Adds Out / In / Total distance and par subtotals for 18-hole courses
- Removes old `.course-table` / `.course-item` styles; adds new `.hole-list`, `.hole-row`, `.hole-visual` etc.

## Test plan

- [ ] Visit a course page for an 18-hole competition and verify all 18 holes render vertically with illustrations
- [ ] Confirm the longest hole's bar is widest and the shortest is narrowest
- [ ] Check Out / In / Total subtotals are correct
- [ ] Test on mobile (≤375px) — bars should compress gracefully, stats remain readable
- [ ] Verify dark mode looks reasonable (green illustrations on dark background)
- [ ] Check a 9-hole course — should show only a Total subtotal, no Out/In

🤖 Generated with [Claude Code](https://claude.com/claude-code)