### PR TITLE
Add 'Add to Home Screen' banner and instructions page

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import { PagesProgressBar as NextNProgress } from 'next-nprogress-bar';
 import React, { useEffect, useState } from 'react';
 import Script from 'next/script';
+import AddToHomeScreen from '../src/AddToHomeScreen.js';
 
 function MyApp({ Component, pageProps }) {
   const [themeColor, setThemeColor] = useState('#ffffff');
@@ -53,6 +54,7 @@ function MyApp({ Component, pageProps }) {
         src="https://plausible.io/js/script.js"
       />
       <div className="blurry-background" />
+      <AddToHomeScreen />
       <main>
         <Component {...pageProps} />
       </main>

--- a/pages/add-to-home-screen.js
+++ b/pages/add-to-home-screen.js
@@ -1,0 +1,73 @@
+import Head from 'next/head';
+import React from 'react';
+import Menu from '../src/Menu.js';
+
+export default function AddToHomeScreen() {
+  return (
+    <div className="add-to-home-screen-page">
+      <Head>
+        <title>Add to home screen – Nordic Golf Tour</title>
+      </Head>
+      <Menu />
+      <h2>Add to home screen</h2>
+      <p className="page-desc">
+        Install this site as an app for quick access to live scores and
+        leaderboards — no app store needed.
+      </p>
+
+      <section className="aths-section">
+        <h3>On iPhone or iPad (Safari)</h3>
+        <ol className="aths-steps">
+          <li>
+            Open this page in <strong>Safari</strong>.
+          </li>
+          <li>
+            Tap the <strong>Share</strong> button{' '}
+            <span className="aths-icon" aria-hidden="true">
+              {/* Share icon */}
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+                <polyline points="16 6 12 2 8 6" />
+                <line x1="12" y1="2" x2="12" y2="15" />
+              </svg>
+            </span>{' '}
+            at the bottom of the screen.
+          </li>
+          <li>
+            Scroll down and tap <strong>Add to Home Screen</strong>.
+          </li>
+          <li>
+            Tap <strong>Add</strong> in the top-right corner.
+          </li>
+        </ol>
+      </section>
+
+      <section className="aths-section">
+        <h3>On Android (Chrome)</h3>
+        <ol className="aths-steps">
+          <li>
+            Open this page in <strong>Chrome</strong>.
+          </li>
+          <li>
+            Tap the <strong>menu</strong>{' '}
+            <span className="aths-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="currentColor">
+                <circle cx="12" cy="5" r="1.5" />
+                <circle cx="12" cy="12" r="1.5" />
+                <circle cx="12" cy="19" r="1.5" />
+              </svg>
+            </span>{' '}
+            in the top-right corner.
+          </li>
+          <li>
+            Tap <strong>Add to Home screen</strong> or{' '}
+            <strong>Install app</strong>.
+          </li>
+          <li>
+            Tap <strong>Add</strong> or <strong>Install</strong> to confirm.
+          </li>
+        </ol>
+      </section>
+    </div>
+  );
+}

--- a/src/AddToHomeScreen.js
+++ b/src/AddToHomeScreen.js
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+import React, { useEffect, useState } from 'react';
+
+const DISMISSED_KEY = 'add-to-home-screen-dismissed-v2';
+
+export default function AddToHomeScreen() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const isStandalone =
+      window.matchMedia('(display-mode: standalone)').matches ||
+      window.navigator.standalone === true;
+    const isDismissed = localStorage.getItem(DISMISSED_KEY);
+    const isTouchDevice = navigator.maxTouchPoints > 0;
+
+    if (!isStandalone && !isDismissed && isTouchDevice) {
+      setVisible(true);
+    }
+  }, []);
+
+  function dismiss() {
+    localStorage.setItem(DISMISSED_KEY, '1');
+    setVisible(false);
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div className="add-to-home-screen-banner">
+      <Link href="/add-to-home-screen">Add to your home screen</Link> for quick
+      access to live scores.
+      <button
+        className="add-to-home-screen-dismiss"
+        onClick={dismiss}
+        aria-label="Dismiss"
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/styles.css
+++ b/styles.css
@@ -233,6 +233,7 @@ a {
 .schedule,
 .sign-in,
 .course,
+.add-to-home-screen-page,
 nav {
   max-width: 600px;
   margin: 0 auto;
@@ -2098,4 +2099,71 @@ h2.player-big-name {
   margin-top: 8px;
   font-size: 12px;
   opacity: 0.5;
+}
+
+/* Add to home screen banner */
+.add-to-home-screen-banner {
+  background-color: var(--primary);
+  color: #fff;
+  text-align: center;
+  padding: 11px 40px 11px 10px;
+  font-size: 13px;
+  position: relative;
+}
+
+.add-to-home-screen-banner a {
+  color: #fff;
+  text-decoration: underline;
+}
+
+.add-to-home-screen-dismiss {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 20px;
+  line-height: 1;
+  padding: 0 4px;
+  opacity: 0.8;
+}
+
+.add-to-home-screen-dismiss:hover {
+  opacity: 1;
+}
+
+/* Add to home screen instructions page */
+.aths-section {
+  margin-bottom: 30px;
+  padding: 0 10px;
+}
+
+.aths-section h3 {
+  margin-bottom: 10px;
+}
+
+.aths-steps {
+  padding-left: 20px;
+  list-style: decimal;
+  line-height: 1.7;
+}
+
+.aths-steps li {
+  margin-bottom: 4px;
+}
+
+.aths-icon {
+  display: inline-block;
+  vertical-align: middle;
+  width: 18px;
+  height: 18px;
+  position: relative;
+  top: -1px;
+}
+
+.aths-icon svg {
+  width: 18px;
+  height: 18px;
 }


### PR DESCRIPTION
## Summary

- Shows a small dismissible banner at the top of every page on touch devices when the site isn't already installed as a PWA
- Dismissal is persisted via `localStorage` so it doesn't reappear
- Links to a new `/add-to-home-screen` page with step-by-step instructions for both iOS (Safari) and Android (Chrome)

## Test plan

- [ ] Visit the site on a mobile device — banner should appear at the top
- [ ] Tap the × button — banner should disappear and not return on reload
- [ ] Tap the link — should navigate to the instructions page
- [ ] Install as PWA and revisit — banner should not appear
- [ ] Visit on desktop — banner should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)