### PR TITLE
Reload start page data when returning to the app

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,8 +1,17 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('@storybook/react-webpack5').StorybookConfig} */
 const config = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: ['@storybook/addon-webpack5-compiler-babel'],
   framework: '@storybook/react-webpack5',
+  webpackFinal: async (config) => {
+    config.resolve.alias['next/router'] = path.resolve(__dirname, 'mocks/next-router.js');
+    return config;
+  },
 };
 
 export default config;

--- a/.storybook/mocks/next-router.js
+++ b/.storybook/mocks/next-router.js
@@ -1,0 +1,15 @@
+export function useRouter() {
+  return {
+    asPath: '/',
+    pathname: '/',
+    query: {},
+    replace: () => Promise.resolve(true),
+    push: () => Promise.resolve(true),
+    back: () => {},
+    events: {
+      on: () => {},
+      off: () => {},
+      emit: () => {},
+    },
+  };
+}

--- a/src/StartPage.js
+++ b/src/StartPage.js
@@ -1,7 +1,8 @@
 import { format } from 'date-fns';
 import Head from 'next/head';
 import Link from 'next/link';
-import React from 'react';
+import { useRouter } from 'next/router';
+import React, { useEffect } from 'react';
 
 import ReportBlurbs from './ReportBlurbs.js';
 import Leaderboard from './Leaderboard.js';
@@ -38,6 +39,22 @@ export default function StartPage({
   reports,
   now: nowMs,
 }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    let wasHidden = false;
+    function handleVisibilityChange() {
+      if (document.visibilityState === 'hidden') {
+        wasHidden = true;
+      } else if (wasHidden) {
+        wasHidden = false;
+        router.replace(router.asPath);
+      }
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [router]);
+
   pastCompetitions.forEach(ensureDates);
   upcomingCompetitions.forEach(ensureDates);
   if (nextCompetition) {


### PR DESCRIPTION
## Summary
- Adds a `visibilitychange` listener on the home page
- When the user returns to the PWA after switching away, triggers a soft navigation (`router.replace`) to re-run `getServerSideProps` and refresh the leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)