### PR TITLE
Add canonical URLs to player and scorecard pages

### DIFF
--- a/pages/[id].js
+++ b/pages/[id].js
@@ -67,6 +67,9 @@ export default function PlayerPage({
             content={`${baseUrl}/players/${player.id}.jpg`}
           />
         )}
+        {baseUrl && (
+          <link rel="canonical" href={`${baseUrl}/${player.slug}`} />
+        )}
         <meta
           name="twitter:card"
           content={baseUrl ? 'summary_large_image' : 'summary'}

--- a/pages/t/[competitionSlug]/players/[playerId]/index.js
+++ b/pages/t/[competitionSlug]/players/[playerId]/index.js
@@ -125,7 +125,7 @@ function Round({ round, colors, courses, now }) {
   );
 }
 
-export default function CompetitionPlayer({ now: nowMs, player, competition }) {
+export default function CompetitionPlayer({ now: nowMs, player, competition, baseUrl }) {
   const now = new Date(nowMs);
   const data = useJsonPData(
     `https://scores.golfbox.dk/Handlers/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057/`,
@@ -148,6 +148,12 @@ export default function CompetitionPlayer({ now: nowMs, player, competition }) {
           name="description"
           content={`Results for ${player.firstName} ${player.lastName} in ${competition.name}`}
         />
+        {baseUrl && (
+          <link
+            rel="canonical"
+            href={`${baseUrl}/t/${competition.slug}/players/${player.id}`}
+          />
+        )}
       </Head>
       <div className="player-profile">
         {loading ? (
@@ -217,7 +223,7 @@ export default function CompetitionPlayer({ now: nowMs, player, competition }) {
   );
 }
 
-export async function getServerSideProps({ params }) {
+export async function getServerSideProps({ params, req }) {
   const [competition, player] = await Promise.all([
     prisma.competition.findUnique({
       where: { slug: params.competitionSlug },
@@ -249,7 +255,9 @@ export async function getServerSideProps({ params }) {
   }
   competition.start = competition.start.getTime();
   competition.end = competition.end.getTime();
+  const protocol = req.headers['x-forwarded-proto'] || 'https';
+  const baseUrl = `${protocol}://${req.headers.host}`;
   return {
-    props: { competition, player, now: Date.now() },
+    props: { competition, player, now: Date.now(), baseUrl },
   };
 }


### PR DESCRIPTION
## Summary

- Adds `<link rel="canonical">` to player profile pages (`/[slug]`), pointing to the clean URL without query params
- Adds `<link rel="canonical">` to tournament scorecard pages (`/t/[slug]/players/[id]`), also with a clean URL

## Why

Google Search Console was indexing many URL variants for the same player page due to UI state parameters (`?season=`, `?stat=`). Each variant was treated as a separate page, splitting crawl budget and diluting page authority. The canonical tag consolidates all variants into a single authoritative URL.

## Test plan

- [ ] Visit a player page with query params (e.g. `/philip-hallstrom?season=2026&stat=avgScore`) and check that the `<link rel="canonical">` in the page source points to `/philip-hallstrom` (no params)
- [ ] Visit a tournament scorecard page and verify the canonical points to the clean `/t/{slug}/players/{id}` URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)