### PR TITLE
Replace JSONP with a server-side proxy for GolfBox API calls

### DIFF
--- a/pages/api/golfbox/[...path].js
+++ b/pages/api/golfbox/[...path].js
@@ -1,14 +1,11 @@
-function parseGolfboxJson(raw) {
-  return JSON.parse(raw.replace(/:!0/g, ':false').replace(/:!1/g, ':true'));
-}
+import fetchGolfboxUrl from '../../../src/fetchGolfboxUrl';
 
 export default async function handler(req, res) {
   const path = req.query.path.join('/');
-  const url = `https://scores.golfbox.dk/Handlers/${path}/`;
-  const response = await fetch(url);
-  if (!response.ok) {
-    return res.status(response.status).end();
+  try {
+    const data = await fetchGolfboxUrl(path);
+    res.status(200).json(data);
+  } catch (e) {
+    res.status(502).json({ error: e.message });
   }
-  const data = parseGolfboxJson(await response.text());
-  res.status(200).json(data);
 }

--- a/pages/api/golfbox/[...path].js
+++ b/pages/api/golfbox/[...path].js
@@ -1,0 +1,14 @@
+function parseGolfboxJson(raw) {
+  return JSON.parse(raw.replace(/:!0/g, ':false').replace(/:!1/g, ':true'));
+}
+
+export default async function handler(req, res) {
+  const path = req.query.path.join('/');
+  const url = `https://scores.golfbox.dk/Handlers/${path}/`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    return res.status(response.status).end();
+  }
+  const data = parseGolfboxJson(await response.text());
+  res.status(200).json(data);
+}

--- a/pages/auth/invalid-token.js
+++ b/pages/auth/invalid-token.js
@@ -1,7 +1,5 @@
 import React, { useEffect } from 'react';
 
-import fetchJsonP from '../../src/fetchJsonP';
-
 export default function InvalidTokenPage() {
   return (
     <div className="profile">

--- a/pages/oom.js
+++ b/pages/oom.js
@@ -2,7 +2,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import React, { useState } from 'react';
 
-import { useJsonPData } from '../src/fetchJsonP';
+import { useGolfboxData } from '../src/useGolfboxData';
 import FavoriteButton from '../src/FavoriteButton';
 import LoadingSkeleton from '../src/LoadingSkeleton';
 import generateSlug from '../src/generateSlug';
@@ -76,7 +76,7 @@ function Player({ entry, onFavorite, lastFavoriteChanged }) {
 
 export default function OrderOfMeritPage() {
   const [lastFavoriteChanged, setLastFavoriteChanged] = useState();
-  const data = useJsonPData(
+  const data = useGolfboxData(
     `/api/golfbox/OrderOfMeritsHandler/GetOrderOfMerit/CustomerId/${process.env.NEXT_PUBLIC_GOLFBOX_CUSTOMER_ID}/language/2057/OrderOfMeritID/${process.env.NEXT_PUBLIC_GOLFBOX_OOM_ID}`,
   );
 

--- a/pages/oom.js
+++ b/pages/oom.js
@@ -77,7 +77,7 @@ function Player({ entry, onFavorite, lastFavoriteChanged }) {
 export default function OrderOfMeritPage() {
   const [lastFavoriteChanged, setLastFavoriteChanged] = useState();
   const data = useJsonPData(
-    `https://scores.golfbox.dk/Handlers/OrderOfMeritsHandler/GetOrderOfMerit/CustomerId/${process.env.NEXT_PUBLIC_GOLFBOX_CUSTOMER_ID}/language/2057/OrderOfMeritID/${process.env.NEXT_PUBLIC_GOLFBOX_OOM_ID}/`,
+    `/api/golfbox/OrderOfMeritsHandler/GetOrderOfMerit/CustomerId/${process.env.NEXT_PUBLIC_GOLFBOX_CUSTOMER_ID}/language/2057/OrderOfMeritID/${process.env.NEXT_PUBLIC_GOLFBOX_OOM_ID}`,
   );
 
   function handleFavoriteChange() {

--- a/pages/t/[competitionSlug]/courses/[courseId]/index.js
+++ b/pages/t/[competitionSlug]/courses/[courseId]/index.js
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import React from 'react';
 
-import { useJsonPData } from '../../../../../src/fetchJsonP';
+import { useGolfboxData } from '../../../../../src/useGolfboxData';
 import LoadingSkeleton from '../../../../../src/LoadingSkeleton';
 import prisma from '../../../../../src/prisma';
 
@@ -24,7 +24,7 @@ export default function Course({ competition }) {
   const router = useRouter();
   const { courseId } = router.query;
 
-  const data = useJsonPData(
+  const data = useGolfboxData(
     `/api/golfbox/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057`,
   );
 

--- a/pages/t/[competitionSlug]/courses/[courseId]/index.js
+++ b/pages/t/[competitionSlug]/courses/[courseId]/index.js
@@ -25,7 +25,7 @@ export default function Course({ competition }) {
   const { courseId } = router.query;
 
   const data = useJsonPData(
-    `https://scores.golfbox.dk/Handlers/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057/`,
+    `/api/golfbox/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057`,
   );
 
   const loading = !data;

--- a/pages/t/[competitionSlug]/index.js
+++ b/pages/t/[competitionSlug]/index.js
@@ -1,4 +1,5 @@
 import CompetitionPage from '../../../src/CompetitionPage.js';
+import fetchGolfboxUrl from '../../../src/fetchGolfboxUrl.js';
 import prisma from '../../../src/prisma';
 import profileProps from '../../../src/profileProps.js';
 
@@ -27,7 +28,22 @@ export async function getServerSideProps({ req, params }) {
   const {
     props: { account },
   } = proProps;
+
+  let golfboxProps = {};
+  try {
+    const [initialData, initialTimesData, initialPlayersData, initialCompetitionData] =
+      await Promise.all([
+        fetchGolfboxUrl(`LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057`),
+        fetchGolfboxUrl(`TeeTimesHandler/GetTeeTimes/CompetitionId/${competition.id}/language/2057`),
+        fetchGolfboxUrl(`PlayersHandler/GetPlayers/CompetitionId/${competition.id}/language/2057`),
+        fetchGolfboxUrl(`CompetitionHandler/GetCompetition/CompetitionId/${competition.id}/language/2057`),
+      ]);
+    golfboxProps = { initialData, initialTimesData, initialPlayersData, initialCompetitionData };
+  } catch (e) {
+    console.error('Failed to prefetch GolfBox data for competition page:', e);
+  }
+
   return {
-    props: { competition, account: account || null, now: Date.now() },
+    props: { competition, account: account || null, now: Date.now(), ...golfboxProps },
   };
 }

--- a/pages/t/[competitionSlug]/index.js
+++ b/pages/t/[competitionSlug]/index.js
@@ -1,5 +1,4 @@
 import CompetitionPage from '../../../src/CompetitionPage.js';
-import fetchGolfboxUrl from '../../../src/fetchGolfboxUrl.js';
 import prisma from '../../../src/prisma';
 import profileProps from '../../../src/profileProps.js';
 
@@ -29,21 +28,7 @@ export async function getServerSideProps({ req, params }) {
     props: { account },
   } = proProps;
 
-  let golfboxProps = {};
-  try {
-    const [initialData, initialTimesData, initialPlayersData, initialCompetitionData] =
-      await Promise.all([
-        fetchGolfboxUrl(`LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057`),
-        fetchGolfboxUrl(`TeeTimesHandler/GetTeeTimes/CompetitionId/${competition.id}/language/2057`),
-        fetchGolfboxUrl(`PlayersHandler/GetPlayers/CompetitionId/${competition.id}/language/2057`),
-        fetchGolfboxUrl(`CompetitionHandler/GetCompetition/CompetitionId/${competition.id}/language/2057`),
-      ]);
-    golfboxProps = { initialData, initialTimesData, initialPlayersData, initialCompetitionData };
-  } catch (e) {
-    console.error('Failed to prefetch GolfBox data for competition page:', e);
-  }
-
   return {
-    props: { competition, account: account || null, now: Date.now(), ...golfboxProps },
+    props: { competition, account: account || null, now: Date.now() },
   };
 }

--- a/pages/t/[competitionSlug]/players/[playerId]/index.js
+++ b/pages/t/[competitionSlug]/players/[playerId]/index.js
@@ -128,10 +128,10 @@ function Round({ round, colors, courses, now }) {
 export default function CompetitionPlayer({ now: nowMs, player, competition, baseUrl }) {
   const now = new Date(nowMs);
   const data = useJsonPData(
-    `https://scores.golfbox.dk/Handlers/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057/`,
+    `/api/golfbox/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057`,
   );
   const timesData = useJsonPData(
-    `https://scores.golfbox.dk/Handlers/TeeTimesHandler/GetTeeTimes/CompetitionId/${competition.id}/language/2057/`,
+    `/api/golfbox/TeeTimesHandler/GetTeeTimes/CompetitionId/${competition.id}/language/2057`,
   );
 
   const loading = !data;

--- a/pages/t/[competitionSlug]/players/[playerId]/index.js
+++ b/pages/t/[competitionSlug]/players/[playerId]/index.js
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import Head from 'next/head';
 import React from 'react';
 
-import { useJsonPData } from '../../../../../src/fetchJsonP';
+import { useGolfboxData } from '../../../../../src/useGolfboxData';
 import LoadingSkeleton from '../../../../../src/LoadingSkeleton';
 import PlayerPhoto from '../../../../../src/PlayerPhoto';
 import fixParValue from '../../../../../src/fixParValue';
@@ -127,10 +127,10 @@ function Round({ round, colors, courses, now }) {
 
 export default function CompetitionPlayer({ now: nowMs, player, competition, baseUrl }) {
   const now = new Date(nowMs);
-  const data = useJsonPData(
+  const data = useGolfboxData(
     `/api/golfbox/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057`,
   );
-  const timesData = useJsonPData(
+  const timesData = useGolfboxData(
     `/api/golfbox/TeeTimesHandler/GetTeeTimes/CompetitionId/${competition.id}/language/2057`,
   );
 

--- a/pages/t/[competitionSlug]/tee-times/index.js
+++ b/pages/t/[competitionSlug]/tee-times/index.js
@@ -3,7 +3,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import React from 'react';
 
-import { useJsonPData } from '../../../../src/fetchJsonP.js';
+import { useGolfboxData } from '../../../../src/useGolfboxData.js';
 import CutInfo from '../../../../src/CutInfo.js';
 import FavoriteButton from '../../../../src/FavoriteButton.js';
 import competitionDateString from '../../../../src/competitionDateString.js';
@@ -76,7 +76,7 @@ function Game({ game }) {
 export default function TeeTimesPage({ competition, now: nowMs, round }) {
   ensureDates(competition);
   const now = new Date(nowMs);
-  const leaderboardData = useJsonPData(
+  const leaderboardData = useGolfboxData(
     `/api/golfbox/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057`,
   );
   const leaderboardEntries = leaderboardData
@@ -85,7 +85,7 @@ export default function TeeTimesPage({ competition, now: nowMs, round }) {
           {},
       )
     : null;
-  const data = useJsonPData(
+  const data = useGolfboxData(
     `/api/golfbox/TeeTimesHandler/GetTeeTimes/CompetitionId/${competition.id}/language/2057`,
   );
   const loading = !data;

--- a/pages/t/[competitionSlug]/tee-times/index.js
+++ b/pages/t/[competitionSlug]/tee-times/index.js
@@ -77,7 +77,7 @@ export default function TeeTimesPage({ competition, now: nowMs, round }) {
   ensureDates(competition);
   const now = new Date(nowMs);
   const leaderboardData = useJsonPData(
-    `https://scores.golfbox.dk/Handlers/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057/`,
+    `/api/golfbox/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057`,
   );
   const leaderboardEntries = leaderboardData
     ? Object.values(
@@ -86,7 +86,7 @@ export default function TeeTimesPage({ competition, now: nowMs, round }) {
       )
     : null;
   const data = useJsonPData(
-    `https://scores.golfbox.dk/Handlers/TeeTimesHandler/GetTeeTimes/CompetitionId/${competition.id}/language/2057/`,
+    `/api/golfbox/TeeTimesHandler/GetTeeTimes/CompetitionId/${competition.id}/language/2057`,
   );
   const loading = !data;
   const usedRound = round || (data && data.ActiveRoundNumber);

--- a/src/CompetitionPage.js
+++ b/src/CompetitionPage.js
@@ -481,19 +481,19 @@ export default function CompetitionPage({
   const now = new Date(nowMs);
   const [lastFavoriteChanged, setLastFavoriteChanged] = useState();
   const data = useJsonPData(
-    `https://scores.golfbox.dk/Handlers/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057/`,
+    `/api/golfbox/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057`,
     initialData,
   );
   const timesData = useJsonPData(
-    `https://scores.golfbox.dk/Handlers/TeeTimesHandler/GetTeeTimes/CompetitionId/${competition.id}/language/2057/`,
+    `/api/golfbox/TeeTimesHandler/GetTeeTimes/CompetitionId/${competition.id}/language/2057`,
     initialTimesData,
   );
   const playersData = useJsonPData(
-    `https://scores.golfbox.dk/Handlers/PlayersHandler/GetPlayers/CompetitionId/${competition.id}/language/2057/`,
+    `/api/golfbox/PlayersHandler/GetPlayers/CompetitionId/${competition.id}/language/2057`,
     initialPlayersData,
   );
   const competitionData = useJsonPData(
-    `https://scores.golfbox.dk/Handlers/CompetitionHandler/GetCompetition/CompetitionId/${competition.id}/language/2057/`,
+    `/api/golfbox/CompetitionHandler/GetCompetition/CompetitionId/${competition.id}/language/2057`,
     initialCompetitionData,
   );
   const loading = loadingOverride || !data || !timesData || !playersData;

--- a/src/CompetitionPage.js
+++ b/src/CompetitionPage.js
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 import DOMPurify from 'dompurify';
 import PlayerPhoto from './PlayerPhoto';
-import { useJsonPData } from './fetchJsonP';
+import { useGolfboxData } from './useGolfboxData';
 import ClockIcon from './ClockIcon';
 import FavoriteButton from './FavoriteButton';
 import Lazy from './Lazy';
@@ -480,19 +480,19 @@ export default function CompetitionPage({
   ensureDates(competition);
   const now = new Date(nowMs);
   const [lastFavoriteChanged, setLastFavoriteChanged] = useState();
-  const data = useJsonPData(
+  const data = useGolfboxData(
     `/api/golfbox/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057`,
     initialData,
   );
-  const timesData = useJsonPData(
+  const timesData = useGolfboxData(
     `/api/golfbox/TeeTimesHandler/GetTeeTimes/CompetitionId/${competition.id}/language/2057`,
     initialTimesData,
   );
-  const playersData = useJsonPData(
+  const playersData = useGolfboxData(
     `/api/golfbox/PlayersHandler/GetPlayers/CompetitionId/${competition.id}/language/2057`,
     initialPlayersData,
   );
-  const competitionData = useJsonPData(
+  const competitionData = useGolfboxData(
     `/api/golfbox/CompetitionHandler/GetCompetition/CompetitionId/${competition.id}/language/2057`,
     initialCompetitionData,
   );

--- a/src/fetchGolfboxUrl.js
+++ b/src/fetchGolfboxUrl.js
@@ -1,0 +1,12 @@
+function parseGolfboxJson(raw) {
+  return JSON.parse(raw.replace(/:!0/g, ':false').replace(/:!1/g, ':true'));
+}
+
+export default async function fetchGolfboxUrl(path) {
+  const url = `https://scores.golfbox.dk/Handlers/${path}/`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`GolfBox ${path} responded with ${response.status}`);
+  }
+  return parseGolfboxJson(await response.text());
+}

--- a/src/fetchJsonP.js
+++ b/src/fetchJsonP.js
@@ -1,17 +1,4 @@
 import { useEffect, useState } from 'react';
-import md5 from 'crypto-js/md5';
-
-export default function fetchJsonP(url) {
-  return new Promise(resolve => {
-    const rndFunctionName = `cb_${md5(url)}`;
-    window[rndFunctionName] = payload => {
-      resolve(payload);
-    };
-    const scriptEl = document.createElement('script');
-    scriptEl.src = `${url}?callback=${rndFunctionName}&_=${Date.now()}`;
-    document.body.appendChild(scriptEl);
-  });
-}
 
 const CACHE = {};
 
@@ -37,7 +24,8 @@ export function useJsonPData(url, defaultData) {
       }
       lastCheck = Date.now();
       console.log(`Fetching ${url}`);
-      const data = await fetchJsonP(url);
+      const res = await fetch(url);
+      const data = await res.json();
       CACHE[url] = data;
       setData(data);
     }

--- a/src/useGolfboxData.js
+++ b/src/useGolfboxData.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 const CACHE = {};
 
-export function useJsonPData(url, defaultData) {
+export function useGolfboxData(url, defaultData) {
   const [data, setData] = useState(defaultData);
   useEffect(() => {
     if (!url) {
@@ -24,10 +24,18 @@ export function useJsonPData(url, defaultData) {
       }
       lastCheck = Date.now();
       console.log(`Fetching ${url}`);
-      const res = await fetch(url);
-      const data = await res.json();
-      CACHE[url] = data;
-      setData(data);
+      try {
+        const res = await fetch(url);
+        if (!res.ok) {
+          console.error(`Failed to fetch ${url}: ${res.status}`);
+          return;
+        }
+        const data = await res.json();
+        CACHE[url] = data;
+        setData(data);
+      } catch (e) {
+        console.error(`Error fetching ${url}:`, e);
+      }
     }
 
     run();

--- a/src/useGolfboxData.js
+++ b/src/useGolfboxData.js
@@ -24,18 +24,13 @@ export function useGolfboxData(url, defaultData) {
       }
       lastCheck = Date.now();
       console.log(`Fetching ${url}`);
-      try {
-        const res = await fetch(url);
-        if (!res.ok) {
-          console.error(`Failed to fetch ${url}: ${res.status}`);
-          return;
-        }
-        const data = await res.json();
-        CACHE[url] = data;
-        setData(data);
-      } catch (e) {
-        console.error(`Error fetching ${url}:`, e);
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error(`Failed to fetch ${url}: ${res.status}`);
       }
+      const data = await res.json();
+      CACHE[url] = data;
+      setData(data);
     }
 
     run();


### PR DESCRIPTION
## Summary

- Adds `pages/api/golfbox/[...path].js`: a catch-all proxy that forwards requests to `scores.golfbox.dk/Handlers/`, parses the non-standard boolean encoding (`:!0`/`:!1`), and returns plain JSON
- Rewrites `useJsonPData` in `fetchJsonP.js` to use `fetch()` instead of injecting `<script>` tags and registering `window` callbacks — no more JSONP
- Updates all client-side GolfBox URLs in `CompetitionPage`, `/oom`, `/tee-times`, `/courses/[courseId]`, and `/players/[playerId]` to hit `/api/golfbox/...` instead of the external domain directly
- Removes the `crypto-js/md5` usage from `fetchJsonP.js` (was only needed to generate unique callback names)
- Removes dead `fetchJsonP` import from `invalid-token.js`

GolfBox doesn't send CORS headers, so direct browser `fetch()` to their API would fail. The proxy runs on our own origin, so no CORS issue.

## Test plan

- [ ] Visit `/oom` — standings table loads
- [ ] Visit a competition page — leaderboard loads and refreshes on window focus
- [ ] Visit tee times, course detail, and player scorecard pages — all load correctly
- [ ] Check browser DevTools Network tab: requests go to `/api/golfbox/...`, not to `scores.golfbox.dk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)