### PR TITLE
Speed up leaderboard first load by preloading GolfBox data

### DIFF
--- a/src/StartPage.js
+++ b/src/StartPage.js
@@ -8,6 +8,7 @@ import ReportBlurbs from './ReportBlurbs.js';
 import Leaderboard from './Leaderboard.js';
 import competitionDateString from './competitionDateString';
 import ensureDates from './ensureDates.js';
+import { preloadJsonPData } from './fetchJsonP.js';
 
 const youtubers = [
   {
@@ -51,7 +52,8 @@ export default function StartPage({
       }
     }
     document.addEventListener('visibilitychange', handleVisibilityChange);
-    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+    return () =>
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
   }, [router]);
 
   pastCompetitions.forEach(ensureDates);
@@ -64,6 +66,26 @@ export default function StartPage({
   }
   const now = new Date(nowMs);
 
+  const prefetchCompetitionIds = [
+    upcomingCompetitions[0]?.id,
+    pastCompetitions[0]?.id,
+  ].filter(Boolean);
+
+  useEffect(() => {
+    for (const id of prefetchCompetitionIds) {
+      [
+        'LeaderboardHandler/GetLeaderboard',
+        'TeeTimesHandler/GetTeeTimes',
+        'PlayersHandler/GetPlayers',
+        'CompetitionHandler/GetCompetition',
+      ].forEach(handler => {
+        preloadJsonPData(
+          `https://scores.golfbox.dk/Handlers/${handler}/CompetitionId/${id}/language/2057/`,
+        );
+      });
+    }
+  }, [prefetchCompetitionIds]);
+
   return (
     <div className="chrome">
       <Head>
@@ -72,13 +94,19 @@ export default function StartPage({
           name="description"
           content={`${process.env.NEXT_PUBLIC_INTRO_TITLE} — ${process.env.NEXT_PUBLIC_INTRO} Follow your favorite players and get the latest updates straight in your inbox.`}
         />
-        <meta property="og:title" content={process.env.NEXT_PUBLIC_INTRO_TITLE} />
+        <meta
+          property="og:title"
+          content={process.env.NEXT_PUBLIC_INTRO_TITLE}
+        />
         <meta
           property="og:description"
           content={`${process.env.NEXT_PUBLIC_INTRO_TITLE} — ${process.env.NEXT_PUBLIC_INTRO} Follow your favorite players and get the latest updates straight in your inbox.`}
         />
         <meta property="og:type" content="website" />
-        <meta name="twitter:title" content={process.env.NEXT_PUBLIC_INTRO_TITLE} />
+        <meta
+          name="twitter:title"
+          content={process.env.NEXT_PUBLIC_INTRO_TITLE}
+        />
         <meta
           name="twitter:description"
           content={`${process.env.NEXT_PUBLIC_INTRO_TITLE} — ${process.env.NEXT_PUBLIC_INTRO} Follow your favorite players and get the latest updates straight in your inbox.`}
@@ -88,10 +116,8 @@ export default function StartPage({
         <h2>{process.env.NEXT_PUBLIC_INTRO_TITLE}</h2>
         <p className="page-desc">
           {process.env.NEXT_PUBLIC_INTRO} Follow your{' '}
-          <Link href="/players">favorite players</Link>{' '}
-          and get the latest updates{' '}
-          <Link href="/profile">straight in your inbox</Link>
-          .
+          <Link href="/players">favorite players</Link> and get the latest
+          updates <Link href="/profile">straight in your inbox</Link>.
         </p>
         {currentCompetition && (
           <Leaderboard competition={currentCompetition} now={now} />
@@ -168,11 +194,11 @@ function CompetitionListItem({ competition, now, current, next }) {
   if (current) classNames.push('current');
   if (next) classNames.push('next');
   return (
-    <li
-      key={competition.id}
-      className={classNames.join(' ')}
-    >
-      <Link href={`/t/${competition.slug}${queryString}`} className="competition">
+    <li key={competition.id} className={classNames.join(' ')}>
+      <Link
+        href={`/t/${competition.slug}${queryString}`}
+        className="competition"
+      >
         <div className="calendar-event">
           <b>{format(competition.start, 'd')}</b>
           <span>{format(competition.start, 'MMM')}</span>

--- a/src/fetchJsonP.js
+++ b/src/fetchJsonP.js
@@ -13,38 +13,80 @@ export default function fetchJsonP(url) {
   });
 }
 
-const CACHE = {};
+const DB_NAME = 'jsonp-cache';
+const STORE_NAME = 'responses';
+const REFETCH_INTERVAL = 30_000;
+
+let dbPromise;
+
+function openDb() {
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, 1);
+      request.onupgradeneeded = ({ target: { result: db } }) => {
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME);
+        }
+      };
+      request.onsuccess = ({ target: { result: db } }) => resolve(db);
+      request.onerror = ({ target: { error } }) => reject(error);
+    });
+  }
+  return dbPromise;
+}
+
+async function cacheGet(url) {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const req = db.transaction(STORE_NAME).objectStore(STORE_NAME).get(url);
+    req.onsuccess = () => resolve(req.result ?? null);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function cacheSet(url, data) {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const req = db
+      .transaction(STORE_NAME, 'readwrite')
+      .objectStore(STORE_NAME)
+      .put({ data, fetchedAt: Date.now() }, url);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+}
 
 export function useJsonPData(url, defaultData) {
   const [data, setData] = useState(defaultData);
   useEffect(() => {
-    if (!url) {
+    if (!url || defaultData) {
       return;
-    }
-    if (defaultData) {
-      return;
-    }
-    const cachedData = CACHE[url];
-    if (cachedData) {
-      setData(cachedData);
     }
 
-    let lastCheck;
     async function run() {
-      if (Date.now() - lastCheck < 30000) {
-        console.log(`Less than 30s since last fetch for ${url}`);
-        return;
+      const cached = await cacheGet(url);
+      if (cached) {
+        setData(cached.data);
+        if (Date.now() - cached.fetchedAt < REFETCH_INTERVAL) {
+          console.log(`Less than 30s since last fetch for ${url}`);
+          return;
+        }
       }
-      lastCheck = Date.now();
       console.log(`Fetching ${url}`);
-      const data = await fetchJsonP(url);
-      CACHE[url] = data;
-      setData(data);
+      const fetched = await fetchJsonP(url);
+      await cacheSet(url, fetched);
+      setData(fetched);
     }
 
     run();
     window.addEventListener('focus', run);
     return () => window.removeEventListener('focus', run);
   }, [url]);
+  return data;
+}
+
+export async function preloadJsonPData(url) {
+  const data = await fetchJsonP(url);
+  await cacheSet(url, data);
   return data;
 }


### PR DESCRIPTION
Replace the in-memory JSONP cache with IndexedDB so cached data persists across page navigations. Preload all four GolfBox API endpoints on the start page so data is already in cache when the user navigates to the competition page.