### PR TITLE
Fix leaderboard redirect to skip hidden competitions

### DIFF
--- a/src/getCurrentCompetition.mjs
+++ b/src/getCurrentCompetition.mjs
@@ -3,6 +3,7 @@ import prisma from './prisma.mjs';
 export default async function getCurrentCompetition() {
   const now = new Date();
   const competitions = await prisma.competition.findMany({
+    where: { visible: true },
     orderBy: { end: 'desc' },
     select: {
       id: true,


### PR DESCRIPTION
## Changes

- Add `where: { visible: true }` filter to `getCurrentCompetition()` query
- Ensures only visible competitions are considered when fetching the current competition
- Prevents leaderboard redirects to hidden or archived competitions