### PR TITLE
Guard against empty competition list hiding all competitions on sync

### DIFF
--- a/scripts/utils/fetchCompetitions.mjs
+++ b/scripts/utils/fetchCompetitions.mjs
@@ -53,8 +53,7 @@ export default async function fetchCompetitions() {
   }
   const json = parseJson(await res.text());
   if (json.ErrorMessage) {
-    console.log('Got error from API', json);
-    return [];
+    throw new Error(`GolfBox API returned an error: ${JSON.stringify(json.ErrorMessage)}`);
   }
   for (const year of Object.values(json.CompetitionData)) {
     for (const month of Object.values(year.Months)) {

--- a/src/syncData.mjs
+++ b/src/syncData.mjs
@@ -373,6 +373,10 @@ export default async function syncData({ full = true } = {}) {
       : new Date().getFullYear();
 
   const allCompetitions = await prisma.competition.findMany();
+  if (competitions.length === 0) {
+    console.warn('Fetched competitions list is empty — skipping visibility updates to avoid hiding all competitions');
+    return;
+  }
   for (const competition of allCompetitions) {
     const newCompetition = competitions.find(c => c.id === competition.id);
     if (!newCompetition) {


### PR DESCRIPTION
## Summary
- `fetchCompetitions`: throws an error when the GolfBox API returns an `ErrorMessage` instead of silently returning `[]`, making the failure visible in logs
- `syncData`: added a safety guard that skips visibility updates when the fetched competitions list is empty, preventing all current-year competitions from being hidden

## Test plan
- [ ] Verify sync runs normally when the API returns competitions as expected
- [ ] Verify that an API `ErrorMessage` response now causes the sync to fail with a logged error rather than hiding competitions
- [ ] Confirm no competitions are hidden if the list comes back empty for any unexpected reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)