### PR TITLE
Open player scorecard in a dialog instead of navigating away

### DIFF
--- a/src/CompetitionPage.js
+++ b/src/CompetitionPage.js
@@ -9,6 +9,7 @@ import ClockIcon from './ClockIcon';
 import FavoriteButton from './FavoriteButton';
 import Lazy from './Lazy';
 import LoadingSkeleton from './LoadingSkeleton';
+import PlayerDialog from './PlayerDialog';
 import competitionDateString from './competitionDateString';
 import ensureDates from './ensureDates.js';
 import CutInfo from './CutInfo';
@@ -231,6 +232,7 @@ function Player({
   now,
   lazy,
   competition,
+  onScorecardClick,
 }) {
   const rounds = getRounds(entry);
   const classes = ['player'];
@@ -283,67 +285,77 @@ function Player({
           </span>
         </Link>
       ) : null}
-      <Link
-        href={
-          rounds.length > 0 && rounds[0].Holes
-            ? `/t/${competition.slug}/players/${entry.MemberID}`
-            : `/${generateSlug(entry)}`
-        }
-        className="player-link"
-      >
-        {!big ? (
-          <span className={positionClassname}>
-            <span>
-              {entry.Position && entry.Position.Calculated ? (
-                entry.Position.Calculated
-              ) : rounds && rounds.length > 0 ? (
-                <ClockIcon
-                  date={getFirstRoundStart(rounds[rounds.length - 1])}
+      {(() => {
+        const inner = (
+          <>
+            {!big ? (
+              <span className={positionClassname}>
+                <span>
+                  {entry.Position && entry.Position.Calculated ? (
+                    entry.Position.Calculated
+                  ) : rounds && rounds.length > 0 ? (
+                    <ClockIcon
+                      date={getFirstRoundStart(rounds[rounds.length - 1])}
+                    />
+                  ) : null}
+                </span>
+                <FavoriteButton
+                  playerId={entry.MemberID}
+                  onChange={onFavoriteChange}
+                  icon
+                  lastFavoriteChanged={lastFavoriteChanged}
                 />
-              ) : null}
-            </span>
-            <FavoriteButton
-              playerId={entry.MemberID}
-              onChange={onFavoriteChange}
-              icon
-              lastFavoriteChanged={lastFavoriteChanged}
-            />
-          </span>
-        ) : null}
-        {!big ? (
-          <span>
-            {entry.FirstName} {entry.LastName}
-            <br />
-            <span className="club">
-              {entry.ClubName}
-              {process.env.NEXT_PUBLIC_SHOW_PHCP
-                ? ` — HCP ${entry.PHCP}`
-                : null}
-            </span>
-          </span>
-        ) : null}
-        {entry.ResultSum && !big ? (
-          <span
-            className={`score${
-              entry.ResultSum.ToParValue < 0 ? ' under-par' : ''
-            }`}
+              </span>
+            ) : null}
+            {!big ? (
+              <span>
+                {entry.FirstName} {entry.LastName}
+                <br />
+                <span className="club">
+                  {entry.ClubName}
+                  {process.env.NEXT_PUBLIC_SHOW_PHCP
+                    ? ` — HCP ${entry.PHCP}`
+                    : null}
+                </span>
+              </span>
+            ) : null}
+            {entry.ResultSum && !big ? (
+              <span
+                className={`score${
+                  entry.ResultSum.ToParValue < 0 ? ' under-par' : ''
+                }`}
+              >
+                {fixParValue(entry.ResultSum.ToParText)}
+              </span>
+            ) : null}
+            <StatsWrapper className="stats" minHeight={statsHeight}>
+              {rounds.map(round => {
+                return (
+                  <Round
+                    key={round.StartDateTime}
+                    round={round}
+                    colors={colors}
+                    now={now}
+                  />
+                );
+              })}
+            </StatsWrapper>
+          </>
+        );
+        return rounds.length > 0 && rounds[0].Holes && onScorecardClick ? (
+          <button
+            type="button"
+            className="player-link"
+            onClick={() => onScorecardClick(entry)}
           >
-            {fixParValue(entry.ResultSum.ToParText)}
-          </span>
-        ) : null}
-        <StatsWrapper className="stats" minHeight={statsHeight}>
-          {rounds.map(round => {
-            return (
-              <Round
-                key={round.StartDateTime}
-                round={round}
-                colors={colors}
-                now={now}
-              />
-            );
-          })}
-        </StatsWrapper>
-      </Link>
+            {inner}
+          </button>
+        ) : (
+          <Link href={`/${generateSlug(entry)}`} className="player-link">
+            {inner}
+          </Link>
+        );
+      })()}
     </li>
   );
 }
@@ -481,6 +493,7 @@ export default function CompetitionPage({
   ensureDates(competition);
   const now = new Date(nowMs);
   const [lastFavoriteChanged, setLastFavoriteChanged] = useState();
+  const [selectedEntry, setSelectedEntry] = useState(null);
   const data = useJsonPData(
     `https://scores.golfbox.dk/Handlers/LeaderboardHandler/GetLeaderboard/CompetitionId/${competition.id}/language/2057/`,
     initialData,
@@ -639,6 +652,7 @@ export default function CompetitionPage({
               isFavorite={favoriteIds.has(winner.MemberID)}
               onFavoriteChange={handleFavoriteChange}
               lastFavoriteChanged={lastFavoriteChanged}
+              onScorecardClick={setSelectedEntry}
             />
           </ul>
         </div>
@@ -662,6 +676,7 @@ export default function CompetitionPage({
                       isFavorite={true}
                       onFavoriteChange={handleFavoriteChange}
                       lastFavoriteChanged={lastFavoriteChanged}
+                      onScorecardClick={setSelectedEntry}
                     />
                   );
                 })}
@@ -685,6 +700,7 @@ export default function CompetitionPage({
                   onFavoriteChange={handleFavoriteChange}
                   lazy={lazyItems && i > 20}
                   lastFavoriteChanged={lastFavoriteChanged}
+                  onScorecardClick={setSelectedEntry}
                 />
               );
             })}
@@ -703,6 +719,12 @@ export default function CompetitionPage({
           </form>
         </div>
       ) : null}
+      <PlayerDialog
+        entry={selectedEntry}
+        competition={competition}
+        data={data}
+        onClose={() => setSelectedEntry(null)}
+      />
     </div>
   );
 }

--- a/src/FavoriteButton.js
+++ b/src/FavoriteButton.js
@@ -34,6 +34,7 @@ export default function FavoriteButton({
 
   const clickHandler = (confirm, e) => {
     e.preventDefault();
+    e.stopPropagation();
     if (isFavorite) {
       if (confirm &&
         !window.confirm(
@@ -77,8 +78,16 @@ export default function FavoriteButton({
   }
 
   return (
-    <button className={classes.join(' ')} onClick={clickHandler.bind(this, false)}>
+    <span
+      role="button"
+      tabIndex="0"
+      className={classes.join(' ')}
+      onClick={clickHandler.bind(this, false)}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') clickHandler(false, e);
+      }}
+    >
       {icon}
-    </button>
+    </span>
   );
 }

--- a/src/PlayerDialog.js
+++ b/src/PlayerDialog.js
@@ -1,0 +1,376 @@
+import Link from 'next/link';
+import React, { useCallback, useEffect, useRef } from 'react';
+
+import PlayerPhoto from './PlayerPhoto';
+import fixParValue from './fixParValue';
+import generateSlug from './generateSlug.mjs';
+
+function getRounds(entry) {
+  if (!entry.Rounds) return [];
+  return Object.keys(entry.Rounds)
+    .map(key => entry.Rounds[key])
+    .reverse();
+}
+
+function getToParClass(score) {
+  if (!score) return 'unknown';
+  if (score.Score.Value === 1) return 'hio';
+  if (score.Score.Value < score.Par - 1) return 'eagle';
+  if (score.Score.Value < score.Par) return 'birdie';
+  if (score.Score.Value > score.Par + 1) return 'bogey-plus';
+  if (score.Score.Value > score.Par) return 'bogey';
+  return 'on-par';
+}
+
+function calcHalfTotals(holeKeys, holeScores) {
+  let par = 0;
+  let score = 0;
+  let hasScore = false;
+  for (const key of holeKeys) {
+    const s = holeScores?.[key];
+    if (s?.Par) par += s.Par;
+    if (s?.Score?.Value > 0) {
+      score += s.Score.Value;
+      hasScore = true;
+    }
+  }
+  return { par: par || null, score: hasScore ? score : null };
+}
+
+function ScorecardHalf({ holeKeys, holeScores, totals = [] }) {
+  return (
+    <div className="player-round-scorecard">
+      <div>
+        <div className="player-round-scorecard-label">Hole</div>
+        <div className="player-round-scorecard-label">Par</div>
+        <div className="player-round-scorecard-label">Result</div>
+      </div>
+      {holeKeys.map((holeKey, i) => {
+        const score = holeScores?.[holeKey];
+        const isLast = i === holeKeys.length - 1;
+        return (
+          <div
+            key={holeKey}
+            className={isLast ? 'player-round-scorecard-hole-last' : undefined}
+          >
+            <div className="player-round-scorecard-val">
+              {holeKey.replace(/^H-?/, '')}
+            </div>
+            <div className="player-round-scorecard-val">{score?.Par}</div>
+            <div
+              className={`player-round-scorecard-val round-score ${getToParClass(
+                score,
+              )}`}
+            >
+              {score?.Score.Value > 0 ? score.Score.Value : null}
+            </div>
+          </div>
+        );
+      })}
+      {totals.map(({ label, par, score }, i) =>
+        label ? (
+          <div key={label} className="player-round-scorecard-total">
+            <div className="player-round-scorecard-label">{label}</div>
+            <div className="player-round-scorecard-val">{par ?? ''}</div>
+            <div
+              className={`player-round-scorecard-val${score !== null && par !== null && score < par ? ' under-par' : ''}`}
+            >
+              {score ?? ''}
+            </div>
+          </div>
+        ) : (
+          <div key={i} />
+        ),
+      )}
+    </div>
+  );
+}
+
+function DialogRound({ round, colors }) {
+  if (!round.Holes || !round.HoleScores) return null;
+
+  const color = Object.values(colors || {}).find(
+    c => c.CourseID === round.CourseRefID,
+  );
+  const courseNameClasses = ['player-round-course'];
+  if (color) courseNameClasses.push(color.CssName);
+
+  const holeKeys = Object.keys(round.Holes).sort(
+    (a, b) =>
+      parseInt(a.replace(/^H-?/, ''), 10) - parseInt(b.replace(/^H-?/, ''), 10),
+  );
+  const front9 = holeKeys.filter(k => parseInt(k.replace(/^H-?/, ''), 10) <= 9);
+  const back9 = holeKeys.filter(k => parseInt(k.replace(/^H-?/, ''), 10) > 9);
+
+  const frontTotals = calcHalfTotals(front9, round.HoleScores);
+  const backTotals = calcHalfTotals(back9, round.HoleScores);
+  const totalPar = (frontTotals.par ?? 0) + (backTotals.par ?? 0) || null;
+  const totalScore =
+    frontTotals.score !== null && backTotals.score !== null
+      ? frontTotals.score + backTotals.score
+      : frontTotals.score ?? backTotals.score;
+
+  return (
+    <div className="player-round page-margin">
+      <div className="player-round-number">
+        <span>Round {round.Number}</span>
+        {round.CourseName && (
+          <span className={courseNameClasses.join(' ')}>
+            {round.CourseName}
+          </span>
+        )}
+      </div>
+      <ScorecardHalf
+        holeKeys={front9}
+        holeScores={round.HoleScores}
+        totals={[
+          { label: 'Out', par: frontTotals.par, score: frontTotals.score },
+          { label: null },
+        ]}
+      />
+      {back9.length > 0 && (
+        <ScorecardHalf
+          holeKeys={back9}
+          holeScores={round.HoleScores}
+          totals={[
+            { label: 'In', par: backTotals.par, score: backTotals.score },
+            { label: 'Total', par: totalPar, score: totalScore },
+          ]}
+        />
+      )}
+    </div>
+  );
+}
+
+export default function PlayerDialog({ entry, competition, data, onClose }) {
+  const dialogRef = useRef(null);
+
+  const handleClose = useCallback(() => {
+    const dialog = dialogRef.current;
+    if (!dialog || !dialog.open) return;
+    dialog.classList.add('closing');
+    dialog.addEventListener(
+      'animationend',
+      () => {
+        dialog.classList.remove('closing');
+        dialog.close();
+      },
+      { once: true },
+    );
+  }, []);
+
+  // Open dialog when entry is set
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (entry && !dialog.open) {
+      dialog.showModal();
+    }
+  }, [entry]);
+
+  // Intercept ESC so it also animates
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    function handleCancel(e) {
+      e.preventDefault();
+      handleClose();
+    }
+    dialog.addEventListener('cancel', handleCancel);
+    return () => dialog.removeEventListener('cancel', handleCancel);
+  }, [handleClose]);
+
+  // Swipe to dismiss on mobile (right swipe)
+  useEffect(() => {
+    if (!entry) return;
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    let startX = 0;
+    let startY = 0;
+    let currentX = 0;
+    let swiping = false;
+    let swipeConfirmed = false;
+
+    function onTouchStart(e) {
+      startX = e.touches[0].clientX;
+      startY = e.touches[0].clientY;
+      currentX = startX;
+      swiping = true;
+      swipeConfirmed = false;
+      dialog.style.transition = 'none';
+      dialog.style.transform = '';
+    }
+
+    function onTouchMove(e) {
+      if (!swiping) return;
+      const dx = e.touches[0].clientX - startX;
+      const dy = e.touches[0].clientY - startY;
+
+      if (!swipeConfirmed) {
+        if (Math.abs(dy) > Math.abs(dx)) {
+          swiping = false; // vertical scroll wins
+          dialog.style.transition = '';
+          return;
+        }
+        if (Math.abs(dx) > 8) {
+          swipeConfirmed = true;
+        }
+      }
+
+      if (swipeConfirmed) {
+        e.preventDefault();
+        currentX = e.touches[0].clientX;
+        const x = Math.max(0, currentX - startX);
+        dialog.style.transform = `translateX(${x}px)`;
+      }
+    }
+
+    function onTouchEnd() {
+      if (!swiping) return;
+      swiping = false;
+      const dx = currentX - startX;
+
+      if (swipeConfirmed && dx > 80) {
+        // Animate out from current drag position (don't reset to 0 first)
+        dialog.style.transition = 'transform 220ms ease-in';
+        requestAnimationFrame(() => {
+          dialog.style.transform = `translateX(${window.innerWidth}px)`;
+          let closed = false;
+          function doClose() {
+            if (closed) return;
+            closed = true;
+            dialog.style.transform = '';
+            dialog.style.transition = '';
+            dialog.close();
+          }
+          function onTransitionEnd(e) {
+            if (e.propertyName === 'transform') {
+              dialog.removeEventListener('transitionend', onTransitionEnd);
+              doClose();
+            }
+          }
+          dialog.addEventListener('transitionend', onTransitionEnd);
+          // Fallback in case transitionend never fires
+          setTimeout(doClose, 300);
+        });
+      } else {
+        // Snap back with a spring feel
+        dialog.style.transition =
+          'transform 300ms cubic-bezier(0.34, 1.2, 0.64, 1)';
+        dialog.style.transform = '';
+        dialog.addEventListener(
+          'transitionend',
+          () => {
+            dialog.style.transition = '';
+          },
+          { once: true },
+        );
+      }
+    }
+
+    dialog.addEventListener('touchstart', onTouchStart, { passive: true });
+    dialog.addEventListener('touchmove', onTouchMove, { passive: false });
+    dialog.addEventListener('touchend', onTouchEnd);
+
+    return () => {
+      dialog.removeEventListener('touchstart', onTouchStart);
+      dialog.removeEventListener('touchmove', onTouchMove);
+      dialog.removeEventListener('touchend', onTouchEnd);
+    };
+  }, [entry, handleClose]);
+
+  // Close on backdrop click
+  function handleDialogClick(e) {
+    if (e.target === dialogRef.current) {
+      handleClose();
+    }
+  }
+
+  const rounds = entry ? getRounds(entry) : [];
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="player-dialog"
+      onClick={handleDialogClick}
+      onClose={onClose}
+    >
+      <div className="player-dialog-inner">
+        <div className="player-dialog-header">
+          <button
+            type="button"
+            className="player-dialog-back"
+            onClick={handleClose}
+            aria-label="Back"
+          >
+            ← {competition.name}
+          </button>
+          <h3 className="player-dialog-title">{competition.name}</h3>
+          <button
+            type="button"
+            className="player-dialog-close"
+            onClick={handleClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+        <div className="player-dialog-main">
+          {entry && (
+            <div className="player-profile">
+              <div className="player-profile-top page-margin">
+                <PlayerPhoto player={entry} />
+                <div>
+                  <b>Player</b>
+                  <Link
+                    href={`/${generateSlug(entry)}`}
+                    className="player-profile-name"
+                    onClick={handleClose}
+                  >
+                    {entry.FirstName} {entry.LastName}
+                  </Link>
+                  <div className="player-profile-club">{entry.ClubName}</div>
+                  <div className="player-profile-actions">
+                    <Link
+                      href={`/${generateSlug(entry)}`}
+                      className="icon-button"
+                      onClick={handleClose}
+                    >
+                      View player profile
+                    </Link>
+                  </div>
+                </div>
+                {entry.ResultSum && (
+                  <>
+                    <span className="player-profile-position">
+                      <b>Position</b>
+                      <span>{entry.Position?.Calculated}</span>
+                    </span>
+                    <span
+                      className={`player-profile-topar${
+                        entry.ResultSum.ToParValue < 0 ? ' under-par' : ''
+                      }`}
+                    >
+                      <b>Score</b>
+                      <span>{fixParValue(entry.ResultSum.ToParText)}</span>
+                    </span>
+                  </>
+                )}
+              </div>
+              <div className="player-profile-rounds">
+                {rounds.map(round => (
+                  <DialogRound
+                    key={round.StartDateTime}
+                    round={round}
+                    colors={data?.CourseColours}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/src/PlayerDialog.js
+++ b/src/PlayerDialog.js
@@ -144,6 +144,7 @@ function DialogRound({ round, colors }) {
 
 export default function PlayerDialog({ entry, competition, data, onClose }) {
   const dialogRef = useRef(null);
+  const mainRef = useRef(null);
 
   const handleClose = useCallback(() => {
     const dialog = dialogRef.current;
@@ -159,12 +160,15 @@ export default function PlayerDialog({ entry, competition, data, onClose }) {
     );
   }, []);
 
-  // Open dialog when entry is set
+  // Open dialog when entry is set; scroll main back to top on each new entry
   useEffect(() => {
     const dialog = dialogRef.current;
     if (!dialog) return;
     if (entry && !dialog.open) {
       dialog.showModal();
+    }
+    if (entry && mainRef.current) {
+      mainRef.current.scrollTop = 0;
     }
   }, [entry]);
 
@@ -316,7 +320,7 @@ export default function PlayerDialog({ entry, competition, data, onClose }) {
             ×
           </button>
         </div>
-        <div className="player-dialog-main">
+        <div className="player-dialog-main" ref={mainRef}>
           {entry && (
             <div className="player-profile">
               <div className="player-profile-top page-margin">

--- a/styles.css
+++ b/styles.css
@@ -2417,4 +2417,7 @@ h2.player-big-name {
   .player-dialog-close {
     display: none;
   }
+  .player-dialog .round-score.eagle:after {
+    display: block;
+  }
 }

--- a/styles.css
+++ b/styles.css
@@ -459,11 +459,13 @@ html.display-standalone nav {
   border-bottom: 1px solid rgba(var(--text-rgb), 0.2);
 }
 
-.leaderboard-page .player a.player-link,
+.leaderboard-page .player .player-link,
 .oom .player {
   all: unset;
   cursor: pointer;
   display: grid;
+  width: 100%;
+  box-sizing: border-box;
   grid-template-columns: 30px auto 80px;
   column-gap: 15px;
   padding: 10px 10px;
@@ -882,7 +884,7 @@ footer {
     line-height: 12px;
   }
   .oom .player,
-  .leaderboard-page .player a.player-link {
+  .leaderboard-page .player .player-link {
     column-gap: 5px;
     font-size: 15px;
   }
@@ -1031,19 +1033,27 @@ footer {
 }
 .player-round-scorecard {
   display: grid;
-  grid-template-columns: repeat(22, 1fr);
-  column-gap: 10px;
+  grid-template-columns: auto repeat(9, 1fr) repeat(2, 1.5fr);
+  column-gap: 6px;
   row-gap: 3px;
   font-size: 12px;
   padding: 10px 0;
   text-align: center;
-  overflow-x: auto;
 }
 .player-round-scorecard > * {
   opacity: 0.7;
 }
 .player-round-scorecard > *:first-child {
   text-align: left;
+}
+.player-round-scorecard-hole-last {
+  border-right: 1px solid currentColor;
+  padding-right: 4px;
+  opacity: 0.7;
+}
+.player-round-scorecard-total {
+  font-weight: bold;
+  text-align: center;
 }
 .player-round-scorecard .round-score {
   opacity: 1;
@@ -1065,6 +1075,10 @@ footer {
 .player-round-scorecard-val {
   line-height: 20px;
   margin-bottom: 5px;
+}
+
+.player-round-scorecard-val.under-par {
+  color: var(--primary);
 }
 
 .icon-button {
@@ -1916,7 +1930,7 @@ body .pemb-page {
   align-items: flex-start;
 }
 
-.leaderboard-page .player.player-entry-big a.player-link {
+.leaderboard-page .player.player-entry-big .player-link {
   grid-template-columns: 0 auto auto;
 }
 h2.player-big-name {
@@ -2219,4 +2233,188 @@ h2.player-big-name {
 .aths-icon svg {
   width: 18px;
   height: 18px;
+}
+
+/* ─── Player dialog ──────────────────────────────────────────────────────── */
+
+.player-dialog {
+  border: none;
+  padding: 0;
+  background: var(--background);
+  color: var(--text);
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  width: min(600px, 92vw);
+  max-height: 80vh;
+  overflow: hidden;
+}
+.player-dialog[open],
+.player-dialog.closing {
+  display: flex;
+  flex-direction: column;
+}
+.player-dialog-inner {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+.player-dialog-main {
+  flex: 1;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 5px;
+}
+
+.player-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+/* Desktop: scale + fade */
+@media (min-width: 601px) {
+  .player-dialog[open] {
+    animation: player-dialog-in 220ms ease-out both;
+  }
+  .player-dialog.closing {
+    animation: player-dialog-out 180ms ease-in forwards;
+  }
+  .player-dialog[open]::backdrop {
+    animation: player-dialog-backdrop-in 220ms ease-out both;
+  }
+  .player-dialog.closing::backdrop {
+    animation: player-dialog-backdrop-out 180ms ease-in forwards;
+  }
+}
+
+@keyframes player-dialog-in {
+  from {
+    opacity: 0;
+    scale: 0.92;
+  }
+}
+@keyframes player-dialog-out {
+  to {
+    opacity: 0;
+    scale: 0.92;
+  }
+}
+@keyframes player-dialog-backdrop-in {
+  from {
+    opacity: 0;
+  }
+}
+@keyframes player-dialog-backdrop-out {
+  to {
+    opacity: 0;
+  }
+}
+
+/* Mobile: full screen, slide in from right */
+@media (max-width: 600px) {
+  .player-dialog {
+    width: 100%;
+    max-width: 100%;
+    height: 100%;
+    max-height: 100%;
+    margin: 0;
+    border-radius: 0;
+    position: fixed;
+    inset: 0;
+  }
+  .player-dialog[open] {
+    animation: player-dialog-in-mobile 260ms cubic-bezier(0.4, 0, 0.2, 1) both;
+  }
+  .player-dialog.closing {
+    animation: player-dialog-out-mobile 220ms cubic-bezier(0.4, 0, 0.2, 1)
+      forwards;
+  }
+  .player-dialog::backdrop {
+    display: none;
+  }
+}
+
+@keyframes player-dialog-in-mobile {
+  from {
+    translate: 100% 0;
+  }
+}
+@keyframes player-dialog-out-mobile {
+  to {
+    translate: 100% 0;
+  }
+}
+
+/* Dialog inner layout */
+.player-dialog-header {
+  display: flex;
+  align-items: center;
+  padding: 15px;
+  flex-shrink: 0;
+  background: var(--background);
+  border-bottom: 1px solid rgba(var(--text-rgb), 0.06);
+  position: relative;
+}
+.player-dialog-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+.player-dialog-back {
+  all: unset;
+  cursor: pointer;
+  align-items: center;
+  gap: 4px;
+  color: var(--primary);
+  font-size: 16px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  display: none;
+}
+.player-dialog-back:active {
+  opacity: 0.7;
+}
+
+.player-dialog-close {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: rgba(var(--text-rgb), 0.08);
+  color: var(--text);
+  font-size: 20px;
+  line-height: 1;
+  margin-left: auto;
+  user-select: none;
+  transition: background 0.15s;
+}
+.player-dialog-close:hover {
+  background: rgba(var(--text-rgb), 0.14);
+}
+
+@media (max-width: 600px) {
+  .player-dialog-back {
+    display: block;
+  }
+  .player-dialog-title {
+    display: none;
+  }
+  .player-dialog-close {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Summary

- Replaces navigation to the player scorecard page with a native `<dialog>` that opens in-place, preserving leaderboard scroll position
- Desktop: scale+fade animation, max 600px wide, 80vh max height with scrollable content area
- Mobile: full-screen slide-in from right, iOS-style "← Back" button, swipe-to-dismiss with spring snap-back
- Scorecard split into front 9 / back 9 rows with Out, In, Tot subtotals (par + score); under-par totals highlighted in primary colour
- Competition title shown in the static dialog header bar

## Test plan

- [x] Click a player on the leaderboard — dialog opens with scorecard
- [x] Close via X button (desktop) — animates out cleanly
- [x] Close via Back button (mobile) — slides out
- [x] Swipe right to dismiss (mobile) — continues from drag position, snaps back if released early
- [x] Scroll scorecard content — header stays fixed
- [x] Out / In / Tot subtotals show correct par and score; under-par score renders in primary colour
- [x] Leaderboard scroll position is preserved after closing dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)