### PR TITLE
Add map link for competition venues

### DIFF
--- a/src/CompetitionPage.js
+++ b/src/CompetitionPage.js
@@ -18,6 +18,7 @@ import generateSlug from './generateSlug.mjs';
 import parseCET from './parseCET';
 import removeCommonCoursePrefix from './removeCommonCoursePrefix.js';
 import YouTubeEmbed from './YouTubeEmbed';
+import locations from './locations.json';
 
 function parseAndFormatDate(dateStr) {
   const d = parseCET(dateStr);
@@ -583,7 +584,20 @@ export default function CompetitionPage({
       <h2 className="leaderboard-page-heading">{competition.name}</h2>
       {competition.venue && (
         <p className="leaderboard-page-subtitle">
-          {competition.venue} –{' '}
+          {locations[competition.venue] ? (
+            <a
+              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(competition.venue)}&center=${locations[competition.venue].lat},${locations[competition.venue].lng}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="venue-map-link"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 20.8995L16.9497 15.9497C19.6834 13.2161 19.6834 8.78392 16.9497 6.05025C14.2161 3.31658 9.78392 3.31658 7.05025 6.05025C4.31658 8.78392 4.31658 13.2161 7.05025 15.9497L12 20.8995ZM12 23.7279L5.63604 17.364C2.12132 13.8492 2.12132 8.15076 5.63604 4.63604C9.15076 1.12132 14.8492 1.12132 18.364 4.63604C21.8787 8.15076 21.8787 13.8492 18.364 17.364L12 23.7279ZM12 13C13.1046 13 14 12.1046 14 11C14 9.89543 13.1046 9 12 9C10.8954 9 10 9.89543 10 11C10 12.1046 10.8954 13 12 13ZM12 15C9.79086 15 8 13.2091 8 11C8 8.79086 9.79086 7 12 7C14.2091 7 16 8.79086 16 11C16 13.2091 14.2091 15 12 15Z"></path></svg>
+              {competition.venue}
+            </a>
+          ) : (
+            competition.venue
+          )}{' '}
+          –{' '}
           {competition.start &&
             competitionDateString(competition, now, { finished })}
           .

--- a/styles.css
+++ b/styles.css
@@ -127,6 +127,17 @@ button {
   margin: 0;
   opacity: 0.7;
 }
+.leaderboard-page-subtitle .venue-map-link {
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2em;
+}
+.leaderboard-page-subtitle .venue-map-link svg {
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+}
 
 .page-tabs {
   display: flex;


### PR DESCRIPTION
## Summary

- Venue names in the leaderboard subtitle that have an entry in `locations.json` become Google Maps links
- Link includes a pin icon (inline SVG) and opens in a new tab
- URL uses the venue name as the search query, with coordinates as a center hint
- Styles live in `styles.css` (no inline styles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)