### PR TITLE
Improve leaderboard subtitle layout with flexbox and dot separators

### DIFF
--- a/src/CompetitionPage.js
+++ b/src/CompetitionPage.js
@@ -597,11 +597,22 @@ export default function CompetitionPage({
             </a>
           ) : (
             competition.venue
-          )}{' '}
-          –{' '}
-          {competition.start &&
-            competitionDateString(competition, now, { finished })}
-          .
+          )}
+          {competition.start && (() => {
+            const { date, suffix } = competitionDateString(competition, now, { finished, parts: true });
+            return (
+              <>
+                <span>•</span>
+                <span>{date}</span>
+                {suffix && (
+                  <>
+                    <span>•</span>
+                    <span>{suffix}</span>
+                  </>
+                )}
+              </>
+            );
+          })()}
         </p>
       )}
       <div className="page-tabs">

--- a/src/competitionDateString.js
+++ b/src/competitionDateString.js
@@ -12,7 +12,7 @@ const DATE_FORMAT = "yyyyMMdd'T'HHmmss";
 export default function competitionDateString(
   competition,
   initialNow = new Date(),
-  { finished } = {},
+  { finished, parts } = {},
 ) {
   const utcMidnight = new Date(
     Date.UTC(
@@ -46,27 +46,33 @@ export default function competitionDateString(
   let suffix = '';
 
   if (finished) {
-    suffix = ` — Played ${numberOfDays + 1} rounds`;
+    suffix = `Played ${numberOfDays + 1} rounds`;
   } else if (start - 60 * 60 * 1000 <= utcMidnight && utcMidnight <= end) {
     // Currently active
-    suffix = ` — Round ${differenceInDays(utcMidnight, start) + 1} of ${
+    suffix = `Round ${differenceInDays(utcMidnight, start) + 1} of ${
       numberOfDays + 1
     }`;
   } else {
     if (utcMidnight > end) {
-      return `Finished ${formatDistance(end, utcMidnight)} ago`;
+      return parts
+        ? { date: `Finished ${formatDistance(end, utcMidnight)} ago` }
+        : `Finished ${formatDistance(end, utcMidnight)} ago`;
     }
     const daysUntilStart = differenceInDays(start, utcMidnight);
     if (daysUntilStart === 1) {
-      return 'Starts tomorrow';
+      return parts ? { date: 'Starts tomorrow' } : 'Starts tomorrow';
     }
     if (daysUntilStart < 8) {
-      suffix = ` — Starts in ${formatDistance(utcMidnight, start)}`;
+      suffix = `Starts in ${formatDistance(utcMidnight, start)}`;
     }
   }
-  if (endDay < startDay) {
-    // crossing into different month
-    return `${format(start, 'MMMM d')}—${format(end, 'MMMM d')}${suffix}`;
+  const dateStr =
+    endDay < startDay
+      ? `${format(start, 'MMMM d')}—${format(end, 'MMMM d')}`
+      : `${format(start, 'MMMM d')}—${format(end, 'd')}`;
+
+  if (parts) {
+    return { date: dateStr, suffix };
   }
-  return `${format(start, 'MMMM d')}—${format(end, 'd')}${suffix}`;
+  return suffix ? `${dateStr} — ${suffix}` : dateStr;
 }

--- a/styles.css
+++ b/styles.css
@@ -126,6 +126,10 @@ button {
   padding: 5px 10px 10px;
   margin: 0;
   opacity: 0.7;
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+  flex-wrap: wrap;
 }
 .leaderboard-page-subtitle .venue-map-link {
   color: inherit;


### PR DESCRIPTION
## Summary

- Converts `.leaderboard-page-subtitle` to a flexbox row with `align-items: center` and `gap: 0.4em`
- Splits venue, date, and round info (e.g. "Played 3 rounds" / "Round 2 of 3") into separate flex items separated by `•` bullet dots
- Extends `competitionDateString` with a `parts` option to return `{ date, suffix }` separately, keeping all existing callers unaffected

## Test plan

- [ ] Finished tournament: shows `⊙ Venue • March 3–5 • Played 3 rounds`
- [ ] Active tournament: shows `⊙ Venue • March 3–5 • Round 2 of 3`
- [ ] Upcoming (within 7 days): shows `⊙ Venue • March 3–5 • Starts in 3 days`
- [ ] No suffix cases ("Starts tomorrow", "Finished X ago"): show only two items
- [ ] All items are vertically centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)