### PR TITLE
Improve SEO: add year to page titles, noindex sign-in

### DIFF
--- a/pages/oom.js
+++ b/pages/oom.js
@@ -93,12 +93,12 @@ export default function OrderOfMeritPage() {
   return (
     <div className="leaderboard-page oom">
       <Head>
-        <title>{`Order of Merit | ${process.env.NEXT_PUBLIC_INTRO_TITLE}`}</title>
+        <title>{`Order of Merit ${new Date().getFullYear()} | ${process.env.NEXT_PUBLIC_INTRO_TITLE}`}</title>
         <meta name="description" content={description || `Order of merit standings for ${process.env.NEXT_PUBLIC_INTRO_TITLE}.`} />
-        <meta property="og:title" content={`Order of Merit | ${process.env.NEXT_PUBLIC_INTRO_TITLE}`} />
+        <meta property="og:title" content={`Order of Merit ${new Date().getFullYear()} | ${process.env.NEXT_PUBLIC_INTRO_TITLE}`} />
         <meta property="og:description" content={description || `Order of merit standings for ${process.env.NEXT_PUBLIC_INTRO_TITLE}.`} />
         <meta property="og:type" content="website" />
-        <meta name="twitter:title" content={`Order of Merit | ${process.env.NEXT_PUBLIC_INTRO_TITLE}`} />
+        <meta name="twitter:title" content={`Order of Merit ${new Date().getFullYear()} | ${process.env.NEXT_PUBLIC_INTRO_TITLE}`} />
         <meta name="twitter:description" content={description || `Order of merit standings for ${process.env.NEXT_PUBLIC_INTRO_TITLE}.`} />
       </Head>
       <h2>Order of merit</h2>

--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -26,23 +26,23 @@ export default function SchedulePage({
   return (
     <div className="chrome">
       <Head>
-        <title>{`Schedule | ${process.env.NEXT_PUBLIC_INTRO_TITLE}`}</title>
+        <title>{`Tour schedule ${selectedYear} | ${process.env.NEXT_PUBLIC_INTRO_TITLE}`}</title>
         <meta
           name="description"
-          content={`Full schedule for the ${new Date().getFullYear()} season of ${
+          content={`Full schedule for the ${selectedYear} season of ${
             process.env.NEXT_PUBLIC_INTRO_TITLE
           }.`}
         />
-        <meta property="og:title" content={`Schedule | ${process.env.NEXT_PUBLIC_INTRO_TITLE}`} />
+        <meta property="og:title" content={`Tour schedule ${selectedYear} | ${process.env.NEXT_PUBLIC_INTRO_TITLE}`} />
         <meta
           property="og:description"
-          content={`Full schedule for the ${new Date().getFullYear()} season of ${process.env.NEXT_PUBLIC_INTRO_TITLE}.`}
+          content={`Full schedule for the ${selectedYear} season of ${process.env.NEXT_PUBLIC_INTRO_TITLE}.`}
         />
         <meta property="og:type" content="website" />
-        <meta name="twitter:title" content={`Schedule | ${process.env.NEXT_PUBLIC_INTRO_TITLE}`} />
+        <meta name="twitter:title" content={`Tour schedule ${selectedYear} | ${process.env.NEXT_PUBLIC_INTRO_TITLE}`} />
         <meta
           name="twitter:description"
-          content={`Full schedule for the ${new Date().getFullYear()} season of ${process.env.NEXT_PUBLIC_INTRO_TITLE}.`}
+          content={`Full schedule for the ${selectedYear} season of ${process.env.NEXT_PUBLIC_INTRO_TITLE}.`}
         />
       </Head>
       <div className="schedule">

--- a/pages/sign-in.js
+++ b/pages/sign-in.js
@@ -1,3 +1,4 @@
+import Head from 'next/head';
 import React from 'react';
 import Link from 'next/link';
 
@@ -7,6 +8,9 @@ import profileProps from '../src/profileProps.js';
 export default function SignInPage({ account }) {
   return (
     <div className="sign-in">
+      <Head>
+        <meta name="robots" content="noindex" />
+      </Head>
       <h2>Sign in</h2>
       <div className="sign-in-main page-margin">
         {account ? (


### PR DESCRIPTION
## Summary

- Schedule page title now includes the selected year (e.g. "Tour schedule 2026") and correctly uses `selectedYear` instead of `new Date().getFullYear()`, so previous-season pages also show the right year
- OOM page title now includes the current year ("Order of Merit 2026")
- Sign-in page gets `<meta name="robots" content="noindex">` to prevent it from appearing as a Google sitelink

🤖 Generated with [Claude Code](https://claude.com/claude-code)