### PR TITLE
Add nationality flags to player displays

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@prisma/client": "^6.8.2",
     "cookie": "^1.1.1",
+    "country-flag-icons": "^1.6.15",
     "crypto-js": "^4.1.1",
     "date-fns": "^2.28.0",
     "dompurify": "^3.2.6",

--- a/pages/[id].js
+++ b/pages/[id].js
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 
 import FavoriteButton from '../src/FavoriteButton';
+import FlagIcon, { getCountryName } from '../src/FlagIcon';
 import PlayerPhoto from '../src/PlayerPhoto';
 import PlayerStatsChart from '../src/PlayerStatsChart';
 import SignInForm from '../src/SignInForm';
@@ -95,7 +96,10 @@ export default function PlayerPage({
           <h2>
             {player.firstName} {player.lastName}
           </h2>
-          <p className="player-page-club">{player.clubName}</p>
+          <p className="player-page-club">
+            <FlagIcon nationality={player.nationality} />
+            {player.clubName || getCountryName(player.nationality)}
+          </p>
           <FavoriteButton onChange={setIsFavorite} playerId={player.id} large />
         </div>
         <Link href="/oom" className="player-page-oom">
@@ -199,6 +203,7 @@ export async function getServerSideProps({ params, query, req }) {
       firstName: true,
       lastName: true,
       clubName: true,
+      nationality: true,
       oomPosition: true,
       competitionScore: {
         orderBy: {

--- a/pages/players.js
+++ b/pages/players.js
@@ -5,6 +5,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import debounce from 'lodash/debounce';
 
 import FavoriteButton from '../src/FavoriteButton';
+import FlagIcon, { getCountryName } from '../src/FlagIcon';
 import ordinal from '../src/ordinal';
 import prisma from '../src/prisma';
 import profileProps from '../src/profileProps.js';
@@ -35,7 +36,10 @@ function Player({ player, onFavorite, lastFavoriteChanged }) {
       <Link href={`/${player.slug}`}>
         {player.firstName} {player.lastName}
         <br />
-        <span className="club">{player.clubName}</span>
+        <span className="club">
+          <FlagIcon nationality={player.nationality} />
+          {player.clubName || getCountryName(player.nationality)}
+        </span>
       </Link>
       <Link href="/oom" className="oom-position">
         {ordinal(player.oomPosition)}
@@ -285,6 +289,7 @@ export async function getServerSideProps({ req }) {
         firstName: true,
         lastName: true,
         clubName: true,
+        nationality: true,
         oomPosition: true,
       },
     }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       cookie:
         specifier: ^1.1.1
         version: 1.1.1
+      country-flag-icons:
+        specifier: ^1.6.15
+        version: 1.6.15
       crypto-js:
         specifier: ^4.1.1
         version: 4.2.0
@@ -1496,6 +1499,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  country-flag-icons@1.6.15:
+    resolution: {integrity: sha512-92HoA8l6DluEidku8tKBftjuFRj4Rv3zDW1lXxCuNnqAxhUSkvso9gM/Afj4F5BnK+wneHIe3ydI+s+4NA29/Q==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -4477,6 +4483,8 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 5.9.3
+
+  country-flag-icons@1.6.15: {}
 
   cross-spawn@7.0.6:
     dependencies:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,7 @@ model Player {
   firstName   String
   lastName    String
   clubName    String?
+  nationality String?
   oomPosition String?
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @default(now())

--- a/src/CompetitionPage.js
+++ b/src/CompetitionPage.js
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import DOMPurify from 'dompurify';
+import FlagIcon from './FlagIcon';
 import PlayerPhoto from './PlayerPhoto';
 import { useJsonPData } from './fetchJsonP';
 import ClockIcon from './ClockIcon';
@@ -276,7 +277,8 @@ function Player({
               {normalizeName(entry.FirstName)} {normalizeName(entry.LastName)}
             </h2>
             <div className="player-big-club">
-              {entry.ClubName}
+              <FlagIcon nationality={entry.Nationality} />
+              {entry.ClubName || entry.Country}
               {process.env.NEXT_PUBLIC_SHOW_PHCP
                 ? ` — HCP ${entry.PHCP}`
                 : null}
@@ -314,7 +316,8 @@ function Player({
                 {normalizeName(entry.FirstName)} {normalizeName(entry.LastName)}
                 <br />
                 <span className="club">
-                  {entry.ClubName}
+                  <FlagIcon nationality={entry.Nationality} />
+                  {entry.ClubName || entry.Country}
                   {process.env.NEXT_PUBLIC_SHOW_PHCP
                     ? ` — HCP ${entry.PHCP}`
                     : null}

--- a/src/FlagIcon.js
+++ b/src/FlagIcon.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import AM from 'country-flag-icons/react/3x2/AM';
+import AR from 'country-flag-icons/react/3x2/AR';
+import AT from 'country-flag-icons/react/3x2/AT';
+import AU from 'country-flag-icons/react/3x2/AU';
+import BE from 'country-flag-icons/react/3x2/BE';
+import CA from 'country-flag-icons/react/3x2/CA';
+import CH from 'country-flag-icons/react/3x2/CH';
+import CZ from 'country-flag-icons/react/3x2/CZ';
+import DE from 'country-flag-icons/react/3x2/DE';
+import DK from 'country-flag-icons/react/3x2/DK';
+import EE from 'country-flag-icons/react/3x2/EE';
+import ES from 'country-flag-icons/react/3x2/ES';
+import FI from 'country-flag-icons/react/3x2/FI';
+import FR from 'country-flag-icons/react/3x2/FR';
+import GB from 'country-flag-icons/react/3x2/GB';
+import GbSct from 'country-flag-icons/react/3x2/GB-SCT';
+import HR from 'country-flag-icons/react/3x2/HR';
+import HU from 'country-flag-icons/react/3x2/HU';
+import IE from 'country-flag-icons/react/3x2/IE';
+import IS from 'country-flag-icons/react/3x2/IS';
+import IT from 'country-flag-icons/react/3x2/IT';
+import JP from 'country-flag-icons/react/3x2/JP';
+import KR from 'country-flag-icons/react/3x2/KR';
+import LT from 'country-flag-icons/react/3x2/LT';
+import LV from 'country-flag-icons/react/3x2/LV';
+import NL from 'country-flag-icons/react/3x2/NL';
+import NO from 'country-flag-icons/react/3x2/NO';
+import NZ from 'country-flag-icons/react/3x2/NZ';
+import PL from 'country-flag-icons/react/3x2/PL';
+import PT from 'country-flag-icons/react/3x2/PT';
+import RO from 'country-flag-icons/react/3x2/RO';
+import RS from 'country-flag-icons/react/3x2/RS';
+import SE from 'country-flag-icons/react/3x2/SE';
+import SK from 'country-flag-icons/react/3x2/SK';
+import UA from 'country-flag-icons/react/3x2/UA';
+import US from 'country-flag-icons/react/3x2/US';
+import ZA from 'country-flag-icons/react/3x2/ZA';
+
+const FLAGS = {
+  AM, AR, AT, AU, BE, CA, CH, CZ, DE, DK, EE, ES, FI, FR, GB,
+  HR, HU, IE, IS, IT, JP, KR, LT, LV, NL, NO, NZ, PL, PT, RO,
+  RS, SE, SK, UA, US, ZA,
+};
+
+// GolfBox uses non-standard "SQ" for Scotland
+const CODE_MAP = { SQ: GbSct };
+
+const COUNTRY_NAMES = {
+  AM: 'Armenia',
+  AR: 'Argentina',
+  AT: 'Austria',
+  AU: 'Australia',
+  BE: 'Belgium',
+  CA: 'Canada',
+  CH: 'Switzerland',
+  CZ: 'Czech Republic',
+  DE: 'Germany',
+  DK: 'Denmark',
+  EE: 'Estonia',
+  ES: 'Spain',
+  FI: 'Finland',
+  FR: 'France',
+  GB: 'Great Britain',
+  HR: 'Croatia',
+  HU: 'Hungary',
+  IE: 'Ireland',
+  IS: 'Iceland',
+  IT: 'Italy',
+  JP: 'Japan',
+  KR: 'South Korea',
+  LT: 'Lithuania',
+  LV: 'Latvia',
+  NL: 'Netherlands',
+  NO: 'Norway',
+  NZ: 'New Zealand',
+  PL: 'Poland',
+  PT: 'Portugal',
+  RO: 'Romania',
+  RS: 'Serbia',
+  SE: 'Sweden',
+  SK: 'Slovakia',
+  SQ: 'Scotland',
+  UA: 'Ukraine',
+  US: 'United States',
+  ZA: 'South Africa',
+};
+
+export function getCountryName(nationality) {
+  return COUNTRY_NAMES[nationality] || null;
+}
+
+export default function FlagIcon({ nationality }) {
+  if (!nationality) return null;
+  const FlagComponent = CODE_MAP[nationality] || FLAGS[nationality];
+  if (!FlagComponent) return null;
+  return <FlagComponent className="flag-icon" />;
+}

--- a/src/Leaderboard.js
+++ b/src/Leaderboard.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import competitionDateString from './competitionDateString.js';
 import fixParValue from './fixParValue';
+import FlagIcon, { getCountryName } from './FlagIcon';
 import normalizeName from './normalizeName.js';
 
 const PLACEHOLDER_ENTRIES = [
@@ -54,7 +55,8 @@ export default function Leaderboard({ competition, now }) {
                     <td>
                       {normalizeName(entry.player.firstName)} {normalizeName(entry.player.lastName)}
                       <div className="leaderboard-club">
-                        {entry.player.clubName}
+                        <FlagIcon nationality={entry.player.nationality} />
+                        {entry.player.clubName || getCountryName(entry.player.nationality)}
                       </div>
                     </td>
                     <td className={scoreClasses.join(' ')}>

--- a/src/syncData.mjs
+++ b/src/syncData.mjs
@@ -63,6 +63,7 @@ async function fetchPlayersFromEntriesList(competition) {
             lastName: entry.LastName.trim(),
             id: entry.MemberID.trim(),
             clubName: entry.ClubName.trim(),
+            nationality: entry.Nationality || null,
           };
           player.slug = generateSlug(player);
           player.competitions = [];
@@ -114,6 +115,7 @@ async function fetchPlayers(competition) {
           lastName: entry.LastName.trim(),
           id: entry.MemberID.trim(),
           clubName: entry.ClubName.trim(),
+          nationality: entry.Nationality || null,
         };
         player.slug = generateSlug(player);
         if (competition.end.getTime() + 24 * 60 * 60 * 1000 < Date.now()) {
@@ -193,6 +195,7 @@ async function fillOOM(players) {
     index[entry.MemberID] = {
       position: entry.Position,
       actualPosition: entry.ActualPosition,
+      nationality: entry.Nationality || null,
     };
   }
   for (const player of players) {
@@ -203,6 +206,9 @@ async function fillOOM(players) {
     } else {
       player.oomPosition = pos.position;
       player.oomActualPosition = pos.actualPosition;
+      if (!player.nationality && pos.nationality) {
+        player.nationality = pos.nationality;
+      }
     }
   }
   return index;
@@ -312,7 +318,7 @@ export default async function syncData({ full = true } = {}) {
       if (oomEntry) {
         // Player is in the OOM but not in the current competition sync.
         // Update their OOM position instead of clearing it.
-        if (player.oomPosition !== oomEntry.position) {
+        if (player.oomPosition !== oomEntry.position || (!player.nationality && oomEntry.nationality)) {
           batchItems.push({
             id: player.id,
             firstName: player.firstName,
@@ -320,6 +326,7 @@ export default async function syncData({ full = true } = {}) {
             clubName: player.clubName,
             slug: player.slug,
             oomPosition: oomEntry.position,
+            nationality: player.nationality || oomEntry.nationality,
           });
         }
       } else if (player.oomPosition !== null) {
@@ -332,7 +339,8 @@ export default async function syncData({ full = true } = {}) {
       newPlayer.firstName !== player.firstName ||
       newPlayer.lastName !== player.lastName ||
       newPlayer.clubName !== player.clubName ||
-      newPlayer.slug !== player.slug
+      newPlayer.slug !== player.slug ||
+      newPlayer.nationality !== player.nationality
     ) {
       batchItems.push(newPlayer);
     }

--- a/styles.css
+++ b/styles.css
@@ -646,8 +646,9 @@ html.display-standalone nav {
 
 .players .player .club,
 .leaderboard-page .club {
-  display: block;
-  opacity: 0.5;
+  display: flex;
+  align-items: center;
+  color: rgba(var(--text-rgb), 0.5);
   font-size: 12px;
   margin: 3px 0 5px;
 }
@@ -1114,8 +1115,11 @@ footer {
   cursor: default;
 }
 .player-page-club {
+  display: flex;
+  align-items: center;
   padding: 10px 0;
   margin-top: 0;
+  color: rgba(var(--text-rgb), 0.5);
 }
 
 .player-page-top h2 {
@@ -1684,8 +1688,10 @@ input.ios-switch:checked:after {
   border-bottom: 1px solid rgba(var(--text-rgb), 0.2);
 }
 .leaderboard-club {
+  display: flex;
+  align-items: center;
   font-size: 12px;
-  opacity: 0.5;
+  color: rgba(var(--text-rgb), 0.5);
   margin-top: 3px;
 }
 .leaderboard-view-all {
@@ -2501,4 +2507,13 @@ h2.player-big-name {
   .player-dialog .round-score.eagle:after {
     display: block;
   }
+}
+
+.flag-icon {
+  width: 1.1em;
+  height: auto;
+  flex-shrink: 0;
+  margin-right: 4px;
+  border-radius: 1px;
+  box-shadow: 0 0 0 1px rgba(var(--text-rgb), 0.15);
 }


### PR DESCRIPTION
## Summary

- Adds `nationality` field to the `Player` model (Prisma schema + DB push)
- Installs `country-flag-icons` and creates a `FlagIcon` component with static imports for 37 nationalities (preserving tree-shaking)
- Displays the country flag next to club name on: home page leaderboard cards, competition leaderboard, individual player page, and players list
- Falls back to country name when club name is missing
- Syncs `Nationality` from GolfBox API in `syncData.mjs`; backfills existing players on next sync run

## Test plan

- [ ] Check leaderboard cards show flags next to club names
- [ ] Check competition page shows flags for all players
- [ ] Check individual player page shows flag
- [ ] Check players list shows flags
- [ ] Verify players without a club show country name instead
- [ ] Verify dark/light mode: flag outline and text color look correct in both

🤖 Generated with [Claude Code](https://claude.com/claude-code)