### PR TITLE
Disable Vercel preview deployments for PRs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,7 @@
 {
+  "github": {
+    "enabled": false
+  },
   "crons": [
     {
       "path": "/api/cron/sync-data",


### PR DESCRIPTION
## Summary
- Adds `"github": { "enabled": false }` to `vercel.json` to prevent Vercel from creating preview deployments when pull requests are opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)