### PR TITLE
Fix player dialog invisible on iPhone landscape

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2369,6 +2369,15 @@ h2.player-big-name {
 
 /* Desktop: scale + fade */
 @media (min-width: 601px) {
+  /* Explicit centering overrides UA stylesheet — fixes iOS Safari landscape bug
+     where margin: auto centering can position the dialog off-screen */
+  .player-dialog {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    margin: 0;
+  }
   .player-dialog[open] {
     animation: player-dialog-in 220ms ease-out both;
   }
@@ -2386,13 +2395,13 @@ h2.player-big-name {
 @keyframes player-dialog-in {
   from {
     opacity: 0;
-    scale: 0.92;
+    transform: translate(-50%, -50%) scale(0.92);
   }
 }
 @keyframes player-dialog-out {
   to {
     opacity: 0;
-    scale: 0.92;
+    transform: translate(-50%, -50%) scale(0.92);
   }
 }
 @keyframes player-dialog-backdrop-in {


### PR DESCRIPTION
## Summary
- On iOS Safari in landscape mode, the `<dialog>` element's UA stylesheet centering (`margin: auto`) positions the dialog off-screen while the `::backdrop` blur/fade still renders — making the screen blur with no visible dialog
- Fixes by explicitly setting `position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); margin: 0` in the desktop media query, overriding the broken UA centering
- Updates the `player-dialog-in` / `player-dialog-out` keyframe animations to use `transform: translate(-50%, -50%) scale(0.92)` instead of the separate `scale` CSS property, so scaling animates from the dialog's visual center rather than an off-center origin

## Test plan
- [ ] Open a player dialog on iPhone in landscape mode — dialog should be visible and centered
- [ ] Verify the open/close scale animation looks correct (scales from center) on desktop
- [ ] Verify the dialog still works normally on desktop browsers
- [ ] Verify mobile (portrait, ≤600px) slide-in animation is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)