### PR TITLE
Add flag to PlayerDialog club line

### DIFF
--- a/src/PlayerDialog.js
+++ b/src/PlayerDialog.js
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import React, { useCallback, useEffect, useRef } from 'react';
 
+import FlagIcon from './FlagIcon';
 import PlayerPhoto from './PlayerPhoto';
 import fixParValue from './fixParValue';
 import generateSlug from './generateSlug.mjs';
@@ -338,7 +339,10 @@ export default function PlayerDialog({ entry, competition, data, onClose }) {
                   >
                     {entry.FirstName} {entry.LastName}
                   </Link>
-                  <div className="player-profile-club">{entry.ClubName}</div>
+                  <div className="player-profile-club">
+                    <FlagIcon nationality={entry.Nationality} />
+                    {entry.ClubName}
+                  </div>
                   <div className="player-profile-actions">
                     <Link
                       href={`/${generateSlug(entry)}`}

--- a/styles.css
+++ b/styles.css
@@ -991,9 +991,12 @@ footer {
 
 .player-profile-club {
   margin: 0;
-  opacity: 0.7;
+  color: rgba(from currentColor r g b / 0.7);
   font-size: 14px;
   margin-top: 5px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
 }
 .player-profile-top {
   display: grid;


### PR DESCRIPTION
## Summary
- Adds `FlagIcon` next to the club name in the player dialog, matching the leaderboard style
- Switches `.player-profile-club` from `opacity: 0.7` to `color: rgba(from currentColor r g b / 0.7)` so the flag renders at full opacity while text remains dimmed
- Makes `.player-profile-club` a flex container with a gap for proper flag + text spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)