### PR TITLE
Enable main branch deploys, disable PR preview builds

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,9 @@
 {
-  "github": {
-    "enabled": false
+  "git": {
+    "deploymentEnabled": {
+      "**": false,
+      "main": true
+    }
   },
   "crons": [
     {


### PR DESCRIPTION
## Summary
- Replaces deprecated `github.enabled: false` with `git.deploymentEnabled`
- Deploys main branch automatically to production
- Skips builds for all PR/feature branches using minimatch wildcard

🤖 Generated with [Claude Code](https://claude.com/claude-code)