### PR TITLE
Truncate club name with ellipsis in PlayerDialog

### DIFF
--- a/src/PlayerDialog.js
+++ b/src/PlayerDialog.js
@@ -341,7 +341,7 @@ export default function PlayerDialog({ entry, competition, data, onClose }) {
                   </Link>
                   <div className="player-profile-club">
                     <FlagIcon nationality={entry.Nationality} />
-                    {entry.ClubName}
+                    <span>{entry.ClubName}</span>
                   </div>
                   <div className="player-profile-actions">
                     <Link

--- a/styles.css
+++ b/styles.css
@@ -989,6 +989,9 @@ footer {
   content: '';
 }
 
+.player-profile-top > div:nth-child(2) {
+  min-width: 0;
+}
 .player-profile-club {
   margin: 0;
   color: rgba(from currentColor r g b / 0.7);
@@ -997,6 +1000,12 @@ footer {
   display: flex;
   align-items: center;
   gap: 5px;
+  overflow: hidden;
+}
+.player-profile-club span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .player-profile-top {
   display: grid;


### PR DESCRIPTION
## Summary
- Wraps club name text in a `<span>` to enable CSS truncation
- Adds `text-overflow: ellipsis` + `white-space: nowrap` to prevent wrapping
- Adds `min-width: 0` to the grid column so it can actually shrink

## Test plan
- [ ] Open PlayerDialog for a player with a long club name and verify it truncates with `…` instead of wrapping or overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)