### PR TITLE
Add share button to player scorecard dialog

### DIFF
--- a/src/CompetitionPage.js
+++ b/src/CompetitionPage.js
@@ -1,8 +1,7 @@
 import { format, startOfDay } from 'date-fns';
 import Head from 'next/head';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import DOMPurify from 'dompurify';
 import FlagIcon from './FlagIcon';
 import PlayerPhoto from './PlayerPhoto';
@@ -349,15 +348,13 @@ function Player({
           </>
         );
         return rounds.length > 0 && rounds[0].Holes && onScorecardClick ? (
-          <Link
-            href={`/t/${competition.slug}?player=${generateSlug(entry)}`}
-            shallow
-            scroll={false}
+          <button
+            type="button"
             className="player-link"
             onClick={() => onScorecardClick(entry)}
           >
             {inner}
-          </Link>
+          </button>
         ) : (
           <Link href={`/${generateSlug(entry)}`} className="player-link">
             {inner}
@@ -500,8 +497,6 @@ export default function CompetitionPage({
 }) {
   ensureDates(competition);
   const now = new Date(nowMs);
-  const router = useRouter();
-  const playerSlug = router.query.player;
   const [lastFavoriteChanged, setLastFavoriteChanged] = useState();
   const [selectedEntry, setSelectedEntry] = useState(null);
   const data = useJsonPData(
@@ -526,11 +521,6 @@ export default function CompetitionPage({
     setLastFavoriteChanged(new Date());
   }, []);
 
-  const handleDialogClose = useCallback(() => {
-    setSelectedEntry(null);
-    const { player: _, ...rest } = router.query;
-    router.replace({ pathname: router.pathname, query: rest }, undefined, { shallow: true, scroll: false });
-  }, [router]);
 
   const finishedResult = getFinishedResult(data);
   const entries = useMemo(
@@ -540,14 +530,6 @@ export default function CompetitionPage({
         : [],
     [data, timesData, playersData],
   );
-
-  useEffect(() => {
-    if (!playerSlug || !entries || !entries.length) return;
-    const entry = entries.find(e => generateSlug(e) === playerSlug);
-    if (entry) {
-      setSelectedEntry(entry);
-    }
-  }, [playerSlug, entries]);
 
   const isMatchPlay = entries && entries[0] && entries[0].Players;
   const finished = isCompetitionFinished(competitionData, data, timesData);
@@ -771,7 +753,7 @@ export default function CompetitionPage({
         entry={selectedEntry}
         competition={competition}
         data={data}
-        onClose={handleDialogClose}
+        onClose={() => setSelectedEntry(null)}
       />
     </div>
   );

--- a/src/CompetitionPage.js
+++ b/src/CompetitionPage.js
@@ -2,7 +2,7 @@ import { format, startOfDay } from 'date-fns';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import DOMPurify from 'dompurify';
 import FlagIcon from './FlagIcon';
 import PlayerPhoto from './PlayerPhoto';
@@ -499,6 +499,7 @@ export default function CompetitionPage({
   ensureDates(competition);
   const now = new Date(nowMs);
   const { query } = useRouter();
+  const handledQueryPlayer = useRef(false);
   const [lastFavoriteChanged, setLastFavoriteChanged] = useState();
   const [selectedEntry, setSelectedEntry] = useState(null);
   const data = useJsonPData(
@@ -534,9 +535,10 @@ export default function CompetitionPage({
   );
 
   useEffect(() => {
-    if (!query.player || !entries || !entries.length) return;
+    if (handledQueryPlayer.current || !query.player || !entries || !entries.length) return;
     const entry = entries.find(e => generateSlug(e) === query.player);
     if (entry) {
+      handledQueryPlayer.current = true;
       setSelectedEntry(entry);
     }
   }, [query.player, entries]);

--- a/src/CompetitionPage.js
+++ b/src/CompetitionPage.js
@@ -1,7 +1,8 @@
 import { format, startOfDay } from 'date-fns';
 import Head from 'next/head';
 import Link from 'next/link';
-import React, { useCallback, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import DOMPurify from 'dompurify';
 import FlagIcon from './FlagIcon';
 import PlayerPhoto from './PlayerPhoto';
@@ -497,6 +498,7 @@ export default function CompetitionPage({
 }) {
   ensureDates(competition);
   const now = new Date(nowMs);
+  const { query } = useRouter();
   const [lastFavoriteChanged, setLastFavoriteChanged] = useState();
   const [selectedEntry, setSelectedEntry] = useState(null);
   const data = useJsonPData(
@@ -530,6 +532,14 @@ export default function CompetitionPage({
         : [],
     [data, timesData, playersData],
   );
+
+  useEffect(() => {
+    if (!query.player || !entries || !entries.length) return;
+    const entry = entries.find(e => generateSlug(e) === query.player);
+    if (entry) {
+      setSelectedEntry(entry);
+    }
+  }, [query.player, entries]);
 
   const isMatchPlay = entries && entries[0] && entries[0].Players;
   const finished = isCompetitionFinished(competitionData, data, timesData);

--- a/src/PlayerDialog.js
+++ b/src/PlayerDialog.js
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import FlagIcon from './FlagIcon';
 import PlayerPhoto from './PlayerPhoto';
@@ -150,6 +150,22 @@ function DialogRound({ round, colors }) {
 export default function PlayerDialog({ entry, competition, data, onClose }) {
   const dialogRef = useRef(null);
   const mainRef = useRef(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = useCallback(async () => {
+    const url = `${window.location.origin}/t/${competition.slug}?player=${generateSlug(entry)}`;
+    if (navigator.share) {
+      try {
+        await navigator.share({ url });
+      } catch {
+        // user cancelled or share failed — ignore
+      }
+    } else {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [entry, competition.slug]);
 
   const handleClose = useCallback(() => {
     const dialog = dialogRef.current;
@@ -369,6 +385,21 @@ export default function PlayerDialog({ entry, competition, data, onClose }) {
                     </span>
                   </>
                 )}
+              </div>
+              <div className="player-profile-share page-margin">
+                <button
+                  type="button"
+                  className="player-dialog-share"
+                  onClick={handleShare}
+                  aria-label="Share scorecard"
+                >
+                  {copied ? (
+                    '✓'
+                  ) : (
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.58582L18.2071 8.79292L16.7929 10.2071L13 6.41424V16H11V6.41424L7.20711 10.2071L5.79289 8.79292L12 2.58582ZM3 18V14H5V18C5 18.5523 5.44772 19 6 19H18C18.5523 19 19 18.5523 19 18V14H21V18C21 19.6569 19.6569 21 18 21H6C4.34315 21 3 19.6569 3 18Z"></path></svg>
+                  )}
+                  {copied ? 'Copied!' : 'Share scorecard'}
+                </button>
               </div>
               <div className="player-profile-rounds">
                 {rounds.map(round => (

--- a/styles.css
+++ b/styles.css
@@ -1013,7 +1013,6 @@ footer {
   gap: 20px;
   align-items: flex-start;
   max-width: 600px;
-  margin: 0 auto 20px;
 }
 .player-profile-course-heading {
   max-width: 600px;
@@ -2526,6 +2525,32 @@ h2.player-big-name {
   transition: background 0.15s;
 }
 .player-dialog-close:hover {
+  background: rgba(var(--text-rgb), 0.14);
+}
+.player-profile-share {
+  padding-top: 6px;
+  padding-bottom: 16px;
+}
+.player-dialog-share {
+  all: unset;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 6px;
+  background: rgba(var(--text-rgb), 0.08);
+  color: var(--text);
+  font-size: 14px;
+  padding: 6px 12px;
+  user-select: none;
+  transition: background 0.15s;
+}
+.player-dialog-share svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+.player-dialog-share:hover {
   background: rgba(var(--text-rgb), 0.14);
 }
 


### PR DESCRIPTION
## Summary
- Adds a share button below the player profile in the scorecard dialog
- Uses `navigator.share` on mobile/supported browsers, falls back to copying the URL to clipboard on desktop
- The shared URL includes a `?player=<slug>` query param pointing directly to the player's scorecard
- Button shows "✓ Copied!" feedback for 2 seconds after clipboard copy

## Test plan
- [ ] Open a player scorecard dialog and click "Share scorecard"
- [ ] On mobile: native share sheet should appear
- [ ] On desktop: URL should be copied to clipboard and button briefly shows "✓ Copied!"
- [ ] Paste the copied URL in a new tab and verify it loads the correct competition page

🤖 Generated with [Claude Code](https://claude.com/claude-code)