### PR TITLE
Use neutral gray for alert style in light mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -205,10 +205,10 @@ a {
 }
 .alert {
   margin: 10px 0;
-  padding: 10px;
-  border-radius: 3px;
-  background-color: var(--primary-lightest);
-  border: 1px solid var(--primary-light);
+  padding: 12px 16px;
+  border-radius: 6px;
+  background-color: var(--light);
+  border: 1px solid var(--medium);
   color: var(--dark);
 }
 .alert.page-margin {


### PR DESCRIPTION
## Summary
- Replaces the red/pink primary color palette on `.alert` with neutral grays (`--light` / `--medium`) in light mode, so informational notices don't look like error states
- Increases padding slightly (`10px` → `12px 16px`) and softens border-radius (`3px` → `6px`) for a cleaner appearance
- Dark mode styling is unchanged

## Test plan
- [ ] Visit a competition page that hasn't started yet and verify the alert looks neutral/gray in light mode
- [ ] Verify dark mode alert appearance is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)