### PR TITLE
Player page fixes: hide OOM label and fix chart rounding

### DIFF
--- a/pages/[id].js
+++ b/pages/[id].js
@@ -102,10 +102,12 @@ export default function PlayerPage({
           </p>
           <FavoriteButton onChange={setIsFavorite} playerId={player.id} large />
         </div>
-        <Link href="/oom" className="player-page-oom">
-          <b>{ordinal(player.oomPosition)}</b>
-          Order of merit
-        </Link>
+        {player.oomPosition ? (
+          <Link href="/oom" className="player-page-oom">
+            <b>{ordinal(player.oomPosition)}</b>
+            Order of merit
+          </Link>
+        ) : null}
       </div>
 
       {isFavorite && !profile && !isLoadingProfile ? (

--- a/src/PlayerStatsChart.js
+++ b/src/PlayerStatsChart.js
@@ -61,7 +61,7 @@ export function computeYearlyStats(competitionScores) {
     .map(([year, data]) => ({
       year: parseInt(year, 10),
       avgScore: data.scores.length
-        ? data.scores.reduce((a, b) => a + b, 0) / data.scores.length
+        ? Math.round(data.scores.reduce((a, b) => a + b, 0) / data.scores.length)
         : null,
       cutPct: data.total > 0 ? (data.cutsMade / data.total) * 100 : null,
       bestScore: data.scores.length ? Math.min(...data.scores) : null,


### PR DESCRIPTION
## Summary

- Hide the Order of Merit label/link on the player page when the player has no OOM position
- Fix misleading chart positions in the avg score graph: when two yearly averages round to the same integer label but differ as floats, the chart placed them at different heights. Rounding at the data level keeps the chart position consistent with the displayed label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)