### PR TITLE
Update leaderboard menu icon to filled bar chart

### DIFF
--- a/src/Menu.js
+++ b/src/Menu.js
@@ -32,7 +32,7 @@ export default function Menu({ activeHref }) {
         <span className="menu-link-inner">
           <span className="menu-link-icon">
             <svg viewBox="0 0 24 24" fill="currentColor">
-              <path d="M20 22H4C3.44772 22 3 21.5523 3 21V3C3 2.44772 3.44772 2 4 2H20C20.5523 2 21 2.44772 21 3V21C21 21.5523 20.5523 22 20 22ZM8 7V9H16V7H8ZM8 11V13H16V11H8ZM8 15V17H16V15H8Z" />
+              <path d="M2 13H8V21H2V13ZM9 3H15V21H9V3ZM16 8H22V21H16V8Z" />
             </svg>
           </span>
           <span className="menu-link-label">Leaderboard</span>


### PR DESCRIPTION
## Summary
- Replaces the previous outlined list icon in the leaderboard menu item with a filled bar chart icon

## Test plan
- [ ] Verify the leaderboard icon in the nav menu displays as three solid filled bars
- [ ] Check icon renders correctly in both light and dark mode
- [ ] Confirm active state styling still applies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)