### PR TITLE
Improve course page with summary, venue link, and par visualization

### DIFF
--- a/pages/t/[competitionSlug]/courses/[courseId]/index.js
+++ b/pages/t/[competitionSlug]/courses/[courseId]/index.js
@@ -6,12 +6,17 @@ import LoadingSkeleton from '../../../../../src/LoadingSkeleton';
 import VenueMapLink from '../../../../../src/VenueMapLink';
 import prisma from '../../../../../src/prisma';
 
-function HoleIllustration({ length, maxLength }) {
+function HoleIllustration({ length, maxLength, par }) {
   const pct = Math.max(15, (length / maxLength) * 100);
+  const segments = par >= 5 ? [2, 2, 1] : par >= 4 ? [2, 1] : [1];
   return (
     <div className="hole-visual" style={{ '--hole-pct': `${pct}%` }}>
       <div className="hole-tee" />
-      <div className="hole-fairway" />
+      <div className="hole-fairway">
+        {segments.map((flex, i) => (
+          <div key={i} className="hole-fairway-segment" style={{ flex }} />
+        ))}
+      </div>
       <div className="hole-green">
         <div className="hole-flagpole" />
         <div className="hole-flag" />
@@ -92,7 +97,7 @@ export default function Course({ competition }) {
                 <React.Fragment key={hole.key}>
                   <div className="hole-row">
                     <span className="hole-num">{hole.number}</span>
-                    <HoleIllustration length={hole.length} maxLength={maxLength} />
+                    <HoleIllustration length={hole.length} maxLength={maxLength} par={hole.par} />
                     <span className="hole-len">{hole.length}m</span>
                     <span className="hole-par">Par {hole.par}</span>
                   </div>

--- a/pages/t/[competitionSlug]/courses/[courseId]/index.js
+++ b/pages/t/[competitionSlug]/courses/[courseId]/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { useJsonPData } from '../../../../../src/fetchJsonP';
 import LoadingSkeleton from '../../../../../src/LoadingSkeleton';
+import VenueMapLink from '../../../../../src/VenueMapLink';
 import prisma from '../../../../../src/prisma';
 
 function HoleIllustration({ length, maxLength }) {
@@ -50,6 +51,10 @@ export default function Course({ competition }) {
   const maxLength = holes.length ? Math.max(...holes.map(h => h.length)) : 1;
   const totalLength = holes.reduce((sum, h) => sum + h.length, 0);
   const totalPar = holes.reduce((sum, h) => sum + h.par, 0);
+  const parCounts = holes.reduce((acc, h) => {
+    acc[h.par] = (acc[h.par] || 0) + 1;
+    return acc;
+  }, {});
   const frontNine = holes.slice(0, 9);
   const backNine = holes.slice(9);
   const frontLength = frontNine.reduce((sum, h) => sum + h.length, 0);
@@ -67,6 +72,21 @@ export default function Course({ competition }) {
             <h2>
               {venue.Name} – {course.Name}
             </h2>
+            <p className="leaderboard-page-subtitle page-margin">
+              <VenueMapLink venue={venue.Name} />
+            </p>
+            {holes.length > 0 && (
+              <p className="course-summary page-margin">
+                {(() => {
+                  const parts = Object.entries(parCounts)
+                    .sort(([a], [b]) => parseInt(b) - parseInt(a))
+                    .map(([par, count]) => `${count} par ${par}${count === 1 ? '' : 's'}`);
+                  const last = parts.pop();
+                  const parDesc = parts.length ? `${parts.join(', ')} and ${last}` : last;
+                  return `A par ${totalPar} course with ${parDesc}, measuring a total of ${totalLength.toLocaleString('en-US')} m off the tips.`;
+                })()}
+              </p>
+            )}
             <div className="hole-list">
               {holes.map((hole, i) => (
                 <React.Fragment key={hole.key}>

--- a/src/CompetitionPage.js
+++ b/src/CompetitionPage.js
@@ -21,7 +21,7 @@ import generateSlug from './generateSlug.mjs';
 import parseCET from './parseCET';
 import removeCommonCoursePrefix from './removeCommonCoursePrefix.js';
 import YouTubeEmbed from './YouTubeEmbed';
-import locations from './locations.json';
+import VenueMapLink from './VenueMapLink';
 
 function parseAndFormatDate(dateStr) {
   const d = parseCET(dateStr);
@@ -601,19 +601,7 @@ export default function CompetitionPage({
       <h2 className="leaderboard-page-heading">{competition.name}</h2>
       {competition.venue && (
         <p className="leaderboard-page-subtitle">
-          {locations[competition.venue] ? (
-            <a
-              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(competition.venue)}&center=${locations[competition.venue].lat},${locations[competition.venue].lng}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="venue-map-link"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 20.8995L16.9497 15.9497C19.6834 13.2161 19.6834 8.78392 16.9497 6.05025C14.2161 3.31658 9.78392 3.31658 7.05025 6.05025C4.31658 8.78392 4.31658 13.2161 7.05025 15.9497L12 20.8995ZM12 23.7279L5.63604 17.364C2.12132 13.8492 2.12132 8.15076 5.63604 4.63604C9.15076 1.12132 14.8492 1.12132 18.364 4.63604C21.8787 8.15076 21.8787 13.8492 18.364 17.364L12 23.7279ZM12 13C13.1046 13 14 12.1046 14 11C14 9.89543 13.1046 9 12 9C10.8954 9 10 9.89543 10 11C10 12.1046 10.8954 13 12 13ZM12 15C9.79086 15 8 13.2091 8 11C8 8.79086 9.79086 7 12 7C14.2091 7 16 8.79086 16 11C16 13.2091 14.2091 15 12 15Z"></path></svg>
-              {competition.venue}
-            </a>
-          ) : (
-            competition.venue
-          )}
+          <VenueMapLink venue={competition.venue} />
           {competition.start && (() => {
             const { date, suffix } = competitionDateString(competition, now, { finished, parts: true });
             return (

--- a/src/VenueMapLink.js
+++ b/src/VenueMapLink.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import locations from './locations.json';
+
+export default function VenueMapLink({ venue }) {
+  if (!venue) return null;
+  const loc = locations[venue];
+  if (!loc) return <span>{venue}</span>;
+  return (
+    <a
+      href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+        venue,
+      )}&center=${loc.lat},${loc.lng}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="venue-map-link"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+      >
+        <path d="M12 20.8995L16.9497 15.9497C19.6834 13.2161 19.6834 8.78392 16.9497 6.05025C14.2161 3.31658 9.78392 3.31658 7.05025 6.05025C4.31658 8.78392 4.31658 13.2161 7.05025 15.9497L12 20.8995ZM12 23.7279L5.63604 17.364C2.12132 13.8492 2.12132 8.15076 5.63604 4.63604C9.15076 1.12132 14.8492 1.12132 18.364 4.63604C21.8787 8.15076 21.8787 13.8492 18.364 17.364L12 23.7279ZM12 13C13.1046 13 14 12.1046 14 11C14 9.89543 13.1046 9 12 9C10.8954 9 10 9.89543 10 11C10 12.1046 10.8954 13 12 13ZM12 15C9.79086 15 8 13.2091 8 11C8 8.79086 9.79086 7 12 7C14.2091 7 16 8.79086 16 11C16 13.2091 14.2091 15 12 15Z" />
+      </svg>
+      {venue}
+    </a>
+  );
+}

--- a/src/locations.json
+++ b/src/locations.json
@@ -22,5 +22,6 @@
   "Barsebäck Golf & Resort": { "lat": 55.7923908, "lng": 12.9419877 },
   "Stensballegaard Golfklub": { "lat": 55.8702547, "lng": 9.9279499 },
   "Visby Golfklubb": { "lat": 57.4409271, "lng": 18.1199838 },
-  "Aalborg Golfklub": { "lat": 57.026767, "lng": 9.782898 }
+  "Aalborg Golfklub": { "lat": 57.026767, "lng": 9.782898 },
+  "Peuramaa Golf Hjortlandet": { "lat": 60.10055578, "lng": 24.46037337 }
 }

--- a/styles.css
+++ b/styles.css
@@ -744,6 +744,12 @@ footer {
   margin-bottom: 15px;
 }
 
+.course-summary {
+  color: var(--secondary);
+  font-size: 14px;
+  margin: -5px 0 15px;
+}
+
 .hole-list {
   max-width: 500px;
   padding: 8px 0;

--- a/styles.css
+++ b/styles.css
@@ -796,7 +796,13 @@ footer {
   transform: translateY(-50%);
   width: calc(var(--hole-pct) - 14px);
   height: 10px;
+  display: flex;
+  gap: 3px;
+}
+
+.hole-fairway-segment {
   background: #4a9e5c;
+  border-radius: 2px;
 }
 
 .hole-green {


### PR DESCRIPTION
## Summary

- Add a course summary below the heading (e.g. "A par 72 course with 6 par 5s, 6 par 4s and 6 par 3s, measuring a total of 6,312 m off the tips")
- Add a venue map link (Google Maps) below the course heading, reusing a new `VenueMapLink` component extracted from `CompetitionPage`
- Add Peuramaa Golf Hjortlandet to `locations.json`
- Visualize hole par in the fairway illustration: par 4s split into two segments (2/3 + 1/3), par 5s into three segments (2/5 + 2/5 + 1/5)
- Add `page-margin` class to the course summary paragraph

## Test plan

- [ ] Visit a course page and verify the summary text appears with correct par and length
- [ ] Verify the venue map link appears and opens Google Maps
- [ ] Verify par 3 holes show a single fairway segment, par 4s show two, par 5s show three
- [ ] Verify fairway segments have rounded corners and gaps between them

🤖 Generated with [Claude Code](https://claude.com/claude-code)