### PR TITLE
Strip trailing " (Entry)" from competition names

### DIFF
--- a/pages/[id].js
+++ b/pages/[id].js
@@ -9,6 +9,7 @@ import PlayerPhoto from '../src/PlayerPhoto';
 import PlayerStatsChart from '../src/PlayerStatsChart';
 import SignInForm from '../src/SignInForm';
 import fixParValue from '../src/fixParValue';
+import formatCompetitionName from '../src/formatCompetitionName';
 import ordinal from '../src/ordinal';
 import prisma from '../src/prisma';
 import useData from '../src/useData';
@@ -170,7 +171,7 @@ export default function PlayerPage({
                 <tr key={comp.competition.name}>
                   <td className="results-table-competition">
                     <Link href={`/t/${comp.competition.slug}`}>
-                      {comp.competition.name}
+                      {formatCompetitionName(comp.competition.name)}
                       <div>{comp.competition.course}</div>
                     </Link>
                   </td>

--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import React, { useState, useEffect } from 'react';
 
 import ensureDates from '../src/ensureDates.js';
+import formatCompetitionName from '../src/formatCompetitionName';
 import prisma from '../src/prisma';
 import locations from '../src/locations.json';
 
@@ -113,7 +114,7 @@ function CompetitionItem({ competition, now, current, previousYear }) {
     >
       <td>
         <Link href={`/t/${competition.slug}${queryString}`}>
-          {competition.name}
+          {formatCompetitionName(competition.name)}
           <br />
         </Link>
         <span className="schedule-venue">{competition.venue}</span>

--- a/pages/t/[competitionSlug]/players/[playerId]/index.js
+++ b/pages/t/[competitionSlug]/players/[playerId]/index.js
@@ -9,6 +9,7 @@ import { useJsonPData } from '../../../../../src/fetchJsonP';
 import LoadingSkeleton from '../../../../../src/LoadingSkeleton';
 import PlayerPhoto from '../../../../../src/PlayerPhoto';
 import fixParValue from '../../../../../src/fixParValue';
+import formatCompetitionName from '../../../../../src/formatCompetitionName';
 import prisma from '../../../../../src/prisma';
 import generateSlug from '../../../../../src/generateSlug';
 
@@ -142,11 +143,11 @@ export default function CompetitionPlayer({ now: nowMs, player, competition, bas
     <div>
       <Head>
         <title>
-          {player.firstName} {player.lastName}'s scorecard in {competition.name}
+          {player.firstName} {player.lastName}'s scorecard in {formatCompetitionName(competition.name)}
         </title>
         <meta
           name="description"
-          content={`Results for ${player.firstName} ${player.lastName} in ${competition.name}`}
+          content={`Results for ${player.firstName} ${player.lastName} in ${formatCompetitionName(competition.name)}`}
         />
         {baseUrl && (
           <link
@@ -161,7 +162,7 @@ export default function CompetitionPlayer({ now: nowMs, player, competition, bas
         ) : (
           <>
             <h2 className="player-profile-course-heading">
-              {competition.name}
+              {formatCompetitionName(competition.name)}
             </h2>
             <div className="player-profile-top page-margin">
               <PlayerPhoto player={player} />

--- a/pages/t/[competitionSlug]/tee-times/index.js
+++ b/pages/t/[competitionSlug]/tee-times/index.js
@@ -7,6 +7,7 @@ import { useJsonPData } from '../../../../src/fetchJsonP.js';
 import CutInfo from '../../../../src/CutInfo.js';
 import FavoriteButton from '../../../../src/FavoriteButton.js';
 import competitionDateString from '../../../../src/competitionDateString.js';
+import formatCompetitionName from '../../../../src/formatCompetitionName';
 import ensureDates from '../../../../src/ensureDates.js';
 import prisma from '../../../../src/prisma';
 import removeCommonCoursePrefix from '../../../../src/removeCommonCoursePrefix.js';
@@ -120,14 +121,14 @@ export default function TeeTimesPage({ competition, now: nowMs, round }) {
   return (
     <div className="tee-times-page">
       <Head>
-        <title>{competition.name} | Tee times</title>
+        <title>{formatCompetitionName(competition.name)} | Tee times</title>
         <meta
           name="description"
-          content={`See tee times for ${competition.name}`}
+          content={`See tee times for ${formatCompetitionName(competition.name)}`}
         />
       </Head>
       <div className="h-intro">Tee times</div>
-      <h2 className="tee-times-page-heading">{competition.name}</h2>
+      <h2 className="tee-times-page-heading">{formatCompetitionName(competition.name)}</h2>
       {competition.venue && (
         <p className="tee-times-page-subtitle">
           {competition.venue} –{' '}

--- a/src/CompetitionPage.js
+++ b/src/CompetitionPage.js
@@ -13,6 +13,7 @@ import Lazy from './Lazy';
 import LoadingSkeleton from './LoadingSkeleton';
 import PlayerDialog from './PlayerDialog';
 import competitionDateString from './competitionDateString';
+import formatCompetitionName from './formatCompetitionName';
 import normalizeName from './normalizeName.js';
 import ensureDates from './ensureDates.js';
 import CutInfo from './CutInfo';
@@ -561,18 +562,18 @@ export default function CompetitionPage({
   return (
     <div className="leaderboard-page">
       <Head>
-        <title>{`${competition.name} | ${getHeading(competition, now, finished)}`}</title>
+        <title>{`${formatCompetitionName(competition.name)} | ${getHeading(competition, now, finished)}`}</title>
         <meta
           name="description"
-          content={`Follow the leaderboard and see tee times for ${competition.name}${competition.venue ? ` at ${competition.venue}` : ''}.`}
+          content={`Follow the leaderboard and see tee times for ${formatCompetitionName(competition.name)}${competition.venue ? ` at ${competition.venue}` : ''}.`}
         />
         <meta
           property="og:title"
-          content={`${competition.name} | ${getHeading(competition, now, finished)}`}
+          content={`${formatCompetitionName(competition.name)} | ${getHeading(competition, now, finished)}`}
         />
         <meta
           property="og:description"
-          content={`Follow the leaderboard and see tee times for ${competition.name}${competition.venue ? ` at ${competition.venue}` : ''}.`}
+          content={`Follow the leaderboard and see tee times for ${formatCompetitionName(competition.name)}${competition.venue ? ` at ${competition.venue}` : ''}.`}
         />
         <meta property="og:type" content="website" />
         {finishedResult?.youtubeId && (
@@ -590,15 +591,15 @@ export default function CompetitionPage({
         )}
         <meta
           name="twitter:title"
-          content={`${competition.name} | ${getHeading(competition, now, finished)}`}
+          content={`${formatCompetitionName(competition.name)} | ${getHeading(competition, now, finished)}`}
         />
         <meta
           name="twitter:description"
-          content={`Follow the leaderboard and see tee times for ${competition.name}${competition.venue ? ` at ${competition.venue}` : ''}.`}
+          content={`Follow the leaderboard and see tee times for ${formatCompetitionName(competition.name)}${competition.venue ? ` at ${competition.venue}` : ''}.`}
         />
       </Head>
       <div className="h-intro">{getHeading(competition, now, finished)}</div>
-      <h2 className="leaderboard-page-heading">{competition.name}</h2>
+      <h2 className="leaderboard-page-heading">{formatCompetitionName(competition.name)}</h2>
       {competition.venue && (
         <p className="leaderboard-page-subtitle">
           <VenueMapLink venue={competition.venue} />

--- a/src/EmbedPage.js
+++ b/src/EmbedPage.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import ensureDates from './ensureDates.js';
 import competitionDateString from './competitionDateString.js';
+import formatCompetitionName from './formatCompetitionName';
 
 export default function EmbedPage({ title, players, competition }) {
   ensureDates(competition);
@@ -24,7 +25,7 @@ export default function EmbedPage({ title, players, competition }) {
             {process.env.NEXT_PUBLIC_TITLE}
           </span>
         </div>
-        <h1>{competition.name}</h1>
+        <h1>{formatCompetitionName(competition.name)}</h1>
         <div className="pemb-date">{competitionDateString(competition)}</div>
         {players.map(player => {
           return (

--- a/src/Leaderboard.js
+++ b/src/Leaderboard.js
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import React from 'react';
 
 import competitionDateString from './competitionDateString.js';
+import formatCompetitionName from './formatCompetitionName';
 import fixParValue from './fixParValue';
 import FlagIcon, { getCountryName } from './FlagIcon';
 import normalizeName from './normalizeName.js';
@@ -20,7 +21,7 @@ export default function Leaderboard({ competition, now }) {
           {finished ? 'Final results' : 'Leaderboard'}
         </div>
         <h4 className="leaderboard-competition-name">
-          <span>{competition.name}</span>
+          <span>{formatCompetitionName(competition.name)}</span>
         </h4>
         <p className="leaderboard-description">
           {competition.venue} —{' '}

--- a/src/PlayerDialog.js
+++ b/src/PlayerDialog.js
@@ -5,6 +5,7 @@ import FlagIcon from './FlagIcon';
 import PlayerPhoto from './PlayerPhoto';
 import fixParValue from './fixParValue';
 import generateSlug from './generateSlug.mjs';
+import formatCompetitionName from './formatCompetitionName';
 
 function getRounds(entry) {
   if (!entry.Rounds) return [];
@@ -329,9 +330,9 @@ export default function PlayerDialog({ entry, competition, data, onClose }) {
             onClick={handleClose}
             aria-label="Back"
           >
-            ← {competition.name}
+            ← {formatCompetitionName(competition.name)}
           </button>
-          <h3 className="player-dialog-title">{competition.name}</h3>
+          <h3 className="player-dialog-title">{formatCompetitionName(competition.name)}</h3>
           <button
             type="button"
             className="player-dialog-close"

--- a/src/StartPage.js
+++ b/src/StartPage.js
@@ -7,6 +7,7 @@ import React, { useEffect, useMemo } from 'react';
 import ReportBlurbs from './ReportBlurbs.js';
 import Leaderboard from './Leaderboard.js';
 import competitionDateString from './competitionDateString';
+import formatCompetitionName from './formatCompetitionName';
 import ensureDates from './ensureDates.js';
 import { preloadJsonPData } from './fetchJsonP.js';
 
@@ -220,7 +221,7 @@ function CompetitionListItem({ competition, now, current, next }) {
         </div>
         <div className="competition-details">
           <h4 className="competition-name">
-            <span>{competition.name}</span>
+            <span>{formatCompetitionName(competition.name)}</span>
           </h4>
           <p>
             {competition.venue} — {competitionDateString(competition, now)}

--- a/src/formatCompetitionName.js
+++ b/src/formatCompetitionName.js
@@ -1,0 +1,3 @@
+export default function formatCompetitionName(name) {
+  return name?.replace(/ \(Entry\)$/, '') ?? name;
+}


### PR DESCRIPTION
## Summary

- Adds `src/formatCompetitionName.js` — a small utility that strips the trailing ` (Entry)` suffix from competition names
- Applies it across all 9 files where competition names are displayed: headings, page `<title>` tags, Open Graph / Twitter meta tags, the player dialog, schedule, tee times, and player scorecard pages

## Test plan

- [ ] Visit a competition page whose name ends with ` (Entry)` and confirm the suffix is gone from the heading and browser tab title
- [ ] Check the schedule page and start page competition list for the same
- [ ] Open a player dialog and verify the back-button label and dialog title are clean
- [ ] Inspect OG/Twitter meta tags (e.g. with a link preview tool) to confirm no ` (Entry)` appears there either

🤖 Generated with [Claude Code](https://claude.com/claude-code)