### PR TITLE
Add canonical link tags to competition and tee-times pages

### DIFF
--- a/pages/t/[competitionSlug]/index.js
+++ b/pages/t/[competitionSlug]/index.js
@@ -27,7 +27,9 @@ export async function getServerSideProps({ req, params }) {
   const {
     props: { account },
   } = proProps;
+  const protocol = req.headers['x-forwarded-proto'] || 'https';
+  const baseUrl = `${protocol}://${req.headers.host}`;
   return {
-    props: { competition, account: account || null, now: Date.now() },
+    props: { competition, account: account || null, now: Date.now(), baseUrl },
   };
 }

--- a/pages/t/[competitionSlug]/tee-times/index.js
+++ b/pages/t/[competitionSlug]/tee-times/index.js
@@ -74,7 +74,7 @@ function Game({ game }) {
   );
 }
 
-export default function TeeTimesPage({ competition, now: nowMs, round }) {
+export default function TeeTimesPage({ competition, now: nowMs, round, baseUrl }) {
   ensureDates(competition);
   const now = new Date(nowMs);
   const leaderboardData = useJsonPData(
@@ -122,6 +122,7 @@ export default function TeeTimesPage({ competition, now: nowMs, round }) {
     <div className="tee-times-page">
       <Head>
         <title>{formatCompetitionName(competition.name)} | Tee times</title>
+        {baseUrl && <link rel="canonical" href={`${baseUrl}/t/${competition.slug}/tee-times`} />}
         <meta
           name="description"
           content={`See tee times for ${formatCompetitionName(competition.name)}`}
@@ -213,7 +214,7 @@ export default function TeeTimesPage({ competition, now: nowMs, round }) {
   );
 }
 
-export async function getServerSideProps({ params, query }) {
+export async function getServerSideProps({ req, params, query }) {
   const competition = await prisma.competition.findUnique({
     where: { slug: params.competitionSlug },
     select: {
@@ -230,7 +231,9 @@ export async function getServerSideProps({ params, query }) {
   }
   competition.start = competition.start.getTime();
   competition.end = competition.end.getTime();
-  const props = { competition, now: Date.now() };
+  const protocol = req.headers['x-forwarded-proto'] || 'https';
+  const baseUrl = `${protocol}://${req.headers.host}`;
+  const props = { competition, now: Date.now(), baseUrl };
   if (query.round) {
     props.round = query.round;
   }

--- a/src/CompetitionPage.js
+++ b/src/CompetitionPage.js
@@ -496,6 +496,7 @@ export default function CompetitionPage({
   competition = {},
   now: nowMs = Date.now(),
   lazyItems = true,
+  baseUrl,
 }) {
   ensureDates(competition);
   const now = new Date(nowMs);
@@ -563,6 +564,7 @@ export default function CompetitionPage({
     <div className="leaderboard-page">
       <Head>
         <title>{`${formatCompetitionName(competition.name)} | ${getHeading(competition, now, finished)}`}</title>
+        {baseUrl && <link rel="canonical" href={`${baseUrl}/t/${competition.slug}`} />}
         <meta
           name="description"
           content={`Follow the leaderboard and see tee times for ${formatCompetitionName(competition.name)}${competition.venue ? ` at ${competition.venue}` : ''}.`}


### PR DESCRIPTION
## Summary

- Adds `<link rel="canonical">` to the competition leaderboard page, pointing to `/t/{slug}` (fixes `?finished=1` duplicates)
- Adds `<link rel="canonical">` to the tee-times page, pointing to `/t/{slug}/tee-times` (fixes `?round=3` duplicates)
- `baseUrl` is derived from request headers following the existing pattern used in other pages

Fixes 1000+ "Duplicate without user-selected canonical" warnings in Google Search Console.

## Test plan

- [ ] Visit `/t/some-competition?finished=1` and check page source for canonical tag pointing to `/t/some-competition`
- [ ] Visit `/t/some-competition/tee-times?round=2` and check page source for canonical tag pointing to `/t/some-competition/tee-times`

🤖 Generated with [Claude Code](https://claude.com/claude-code)