### PR TITLE
Improve footer and add About page

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -108,7 +108,7 @@ function MyApp({ Component, pageProps }) {
         <Component {...pageProps} />
       </main>
       <footer>
-        by <a href="https://github.com/trotzig/golf-leaderboard">@trotzig</a>
+        By <a href="https://github.com/trotzig">@trotzig</a> 2022–{new Date().getFullYear()} · <a href="/about">About</a> this open-source website
       </footer>
     </div>
   );

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,0 +1,77 @@
+import Head from 'next/head';
+import React from 'react';
+
+export default function About() {
+  return (
+    <div className="about-page">
+      <Head>
+        <title>About – Nordic Golf Tour</title>
+      </Head>
+      <h2>About</h2>
+      <p className="page-desc">
+        An unofficial fan site for the{' '}
+        <a href="https://cutterbuck.se/">Cutter &amp; Buck Tour</a>, the Nordic
+        professional golf tour for men.
+      </p>
+
+      <section className="about-section">
+        <h3>Why this site exists</h3>
+        <p>
+          I built this site because I wanted a better way to follow my friends
+          playing on the tour. The official tools weren't great for quickly
+          checking live scores and standings, so I made something that works the
+          way I wanted.
+        </p>
+      </section>
+
+      <section className="about-section">
+        <h3>Data</h3>
+        <p>
+          Live scores and leaderboard data are fetched from the GolfBox API and
+          updated continuously throughout each tournament round. Statistics may
+          be incorrect or delayed — this site is not affiliated with the tour
+          and makes no guarantees about accuracy.
+        </p>
+      </section>
+
+      <section className="about-section">
+        <h3>Open source</h3>
+        <p>
+          This site is open source. You can find the code on{' '}
+          <a href="https://github.com/trotzig/golf-leaderboard">GitHub</a>.
+          Contributions and bug reports are welcome.
+        </p>
+      </section>
+
+      <section className="about-section">
+        <h3>A note about AI</h3>
+        <p>
+          Parts of this site were built with help from{' '}
+          <a href="https://www.anthropic.com/">Anthropic</a>'s AI, Claude.
+        </p>
+      </section>
+
+      <section className="about-section">
+        <h3>Related links</h3>
+        <ul className="about-links">
+          <li>
+            <a href="https://tournytt.se/tour/cutter-buck-tour">Tournytt</a> —
+            news and coverage of the Cutter &amp; Buck Tour
+          </li>
+          <li>
+            <a href="https://cutterbuck.se/">Cutter &amp; Buck</a> — title
+            sponsor of the tour
+          </li>
+        </ul>
+      </section>
+
+      <section className="about-section">
+        <h3>Contact</h3>
+        <p>
+          For inquiries about this website, contact me directly at
+          henric@happo.io.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/styles.css
+++ b/styles.css
@@ -249,6 +249,7 @@ a {
 .sign-in,
 .course,
 .add-to-home-screen-page,
+.about-page,
 nav {
   max-width: 600px;
   margin: 0 auto;
@@ -674,8 +675,18 @@ main {
 
 footer {
   text-align: center;
-  opacity: 0.3;
-  padding: 100px 10px;
+  opacity: 0.4;
+  padding: 80px 10px 60px;
+  font-size: 14px;
+}
+
+footer a {
+  color: inherit;
+  text-decoration: none;
+}
+
+footer a:hover {
+  text-decoration: underline;
 }
 
 .oom .round {
@@ -2380,6 +2391,39 @@ h2.player-big-name {
 .aths-icon svg {
   width: 18px;
   height: 18px;
+}
+
+/* About page */
+.about-section {
+  margin-bottom: 30px;
+  padding: 0 10px;
+}
+
+.about-section h3 {
+  padding-left: 0;
+  padding-right: 0;
+  margin-bottom: 4px;
+}
+
+.about-section p,
+.about-section ul {
+  margin-top: 0;
+}
+
+.about-section p {
+  line-height: 1.6;
+  opacity: 0.85;
+}
+
+.about-links {
+  padding-left: 20px;
+  list-style: disc;
+  line-height: 1.8;
+}
+
+.about-links a {
+  color: inherit;
+  text-decoration: underline;
 }
 
 /* ─── Player dialog ──────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- Footer updated to show author credit with year range and a link to a new About page
- New `/about` page covers: why the site was built, data disclaimer, open source info, AI usage note (Anthropic/Claude), related links (Tournytt, Cutter & Buck), and contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)