### PR TITLE
Open player scorecard when clicking competition link from player page

### DIFF
--- a/pages/[id].js
+++ b/pages/[id].js
@@ -10,6 +10,7 @@ import PlayerStatsChart from '../src/PlayerStatsChart';
 import SignInForm from '../src/SignInForm';
 import fixParValue from '../src/fixParValue';
 import formatCompetitionName from '../src/formatCompetitionName';
+import generateSlug from '../src/generateSlug.mjs';
 import ordinal from '../src/ordinal';
 import prisma from '../src/prisma';
 import useData from '../src/useData';
@@ -170,7 +171,7 @@ export default function PlayerPage({
               return (
                 <tr key={comp.competition.name}>
                   <td className="results-table-competition">
-                    <Link href={`/t/${comp.competition.slug}`}>
+                    <Link href={`/t/${comp.competition.slug}?player=${generateSlug(player)}`}>
                       {formatCompetitionName(comp.competition.name)}
                       <div>{comp.competition.course}</div>
                     </Link>


### PR DESCRIPTION
## Summary
- Competition links on the player page (`/[slug]`) now include a `?player=` query param with the player's slug
- The competition page already had logic to read this param and auto-open the player's scorecard dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)