### PR TITLE
Add month headlines to schedule page

### DIFF
--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -72,23 +72,32 @@ export default function SchedulePage({
           </div>
         )}
         <table className="results-table page-margin">
-          <thead>
-            <tr>
-              <th>Event</th>
-              <th>Dates</th>
-            </tr>
-          </thead>
+
           {competitions.length > 0 && (
             <tbody>
-              {competitions.map(c => (
-                <CompetitionItem
-                  key={c.id}
-                  competition={c}
-                  now={now}
-                  current={currentCompetition && currentCompetition.id === c.id}
-                  previousYear={selectedYear < new Date(nowMs).getFullYear()}
-                />
-              ))}
+              {competitions.flatMap((c, i) => {
+                const month = format(new Date(c.start), 'MMMM');
+                const prevMonth =
+                  i > 0 ? format(new Date(competitions[i - 1].start), 'MMMM') : null;
+                const rows = [];
+                if (month !== prevMonth) {
+                  rows.push(
+                    <tr key={`month-${month}`} className="schedule-month-header">
+                      <td colSpan={2}>{month}</td>
+                    </tr>,
+                  );
+                }
+                rows.push(
+                  <CompetitionItem
+                    key={c.id}
+                    competition={c}
+                    now={now}
+                    current={currentCompetition && currentCompetition.id === c.id}
+                    previousYear={selectedYear < new Date(nowMs).getFullYear()}
+                  />,
+                );
+                return rows;
+              })}
             </tbody>
           )}
         </table>
@@ -145,7 +154,7 @@ export async function getServerSideProps({ query }) {
   const yearEnd = new Date(selectedYear + 1, 0, 1);
 
   const competitions = await prisma.competition.findMany({
-    orderBy: { end: 'asc' },
+    orderBy: { start: 'asc' },
     where: {
       visible: true,
       start: { gte: yearStart, lt: yearEnd },

--- a/styles.css
+++ b/styles.css
@@ -1519,6 +1519,17 @@ input.ios-switch:checked:after {
   opacity: 0.7;
 }
 
+.schedule-month-header td {
+  padding-top: 24px;
+  padding-bottom: 4px;
+  font-weight: bold;
+  font-size: 0.85em;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.5;
+  border: none;
+}
+
 .competition-list-item.past {
   opacity: 0.5;
 }


### PR DESCRIPTION
## Summary
- Groups schedule events by start month with uppercase section headers between groups
- Removes the redundant "Event" / "Dates" column headers
- Fixes sort order to use `start` date instead of `end` date (prevents a September-starting event from appearing under an October header)

## Test plan
- [ ] Visit `/schedule` and verify month headers appear between groups
- [ ] Verify events spanning month boundaries are grouped by their start month
- [ ] Verify dark mode looks good

🤖 Generated with [Claude Code](https://claude.com/claude-code)