### PR TITLE
Style next event with left primary border

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -439,11 +439,10 @@ html.display-standalone nav {
 }
 
 .competitions li.next .competition {
-  border: 3px solid currentColor;
-  border-radius: 6px;
-  padding: 10px 12px 14px;
-  column-gap: 16px;
+  border-left: 5px solid var(--primary);
   align-items: start;
+  column-gap: 16px;
+  padding: 5px 15px;
 }
 .competitions li.next .competition::before {
   content: 'Next event';


### PR DESCRIPTION
## Summary
- Replace full border + border-radius on the next event card with a left-side primary color border
- Update padding to `5px 15px`

🤖 Generated with [Claude Code](https://claude.com/claude-code)