### PR TITLE
Add admin dashboard

### DIFF
--- a/pages/admin/dashboard.js
+++ b/pages/admin/dashboard.js
@@ -1,0 +1,252 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import prisma from '../../src/prisma';
+
+const ADMIN_EMAILS = ['henric.trotzig@gmail.com', 'henric.persson@gmail.com'];
+
+function formatDate(date) {
+  if (!date) return '—';
+  return new Date(date).toLocaleDateString('en-SE', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export default function AdminDashboard({
+  recentSignIns,
+  topSubscribers,
+  topFavoritedPlayers,
+  mostActivePlayers,
+  lowestAvgScorePlayers,
+  minComps,
+}) {
+  const router = useRouter();
+
+  function handleMinCompsChange(e) {
+    router.push({ query: { minComps: e.target.value } }, undefined, { scroll: false });
+  }
+
+  return (
+    <div className="admin-dashboard">
+      <h2>Admin dashboard</h2>
+
+      <div className="admin-grid">
+        <div>
+          <h3>Latest sign-ups</h3>
+          <table className="admin-table">
+            <thead>
+              <tr>
+                <th>Email</th>
+                <th>Signed up</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recentSignIns.map((row, i) => (
+                <tr key={i}>
+                  <td>{row.email}</td>
+                  <td>{formatDate(row.createdAt)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div>
+          <h3>Most subscribed accounts</h3>
+          <table className="admin-table">
+            <thead>
+              <tr>
+                <th>Email</th>
+                <th>Favorites</th>
+              </tr>
+            </thead>
+            <tbody>
+              {topSubscribers.map((row, i) => (
+                <tr key={i}>
+                  <td>{row.email}</td>
+                  <td>{row.favoriteCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div>
+          <h3>Most favorited players</h3>
+          <table className="admin-table">
+            <thead>
+              <tr>
+                <th>Player</th>
+                <th>Favorites</th>
+              </tr>
+            </thead>
+            <tbody>
+              {topFavoritedPlayers.map((row, i) => (
+                <tr key={i}>
+                  <td>
+                    <a href={`/${row.slug}`}>
+                      {row.firstName} {row.lastName}
+                    </a>
+                  </td>
+                  <td>{row.favoriteCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div>
+          <h3>Most competitions played</h3>
+          <table className="admin-table">
+            <thead>
+              <tr>
+                <th>Player</th>
+                <th>Competitions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {mostActivePlayers.map((row, i) => (
+                <tr key={i}>
+                  <td>
+                    <a href={`/${row.slug}`}>
+                      {row.firstName} {row.lastName}
+                    </a>
+                  </td>
+                  <td>{row.competitionCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div>
+          <h3>Lowest average score</h3>
+          <label className="admin-select-label">
+            Min competitions:{' '}
+            <select value={minComps} onChange={handleMinCompsChange}>
+              {Array.from({ length: 40 }, (_, i) => i + 1).map(n => (
+                <option key={n} value={n}>{n}</option>
+              ))}
+            </select>
+          </label>
+          <table className="admin-table">
+            <thead>
+              <tr>
+                <th>Player</th>
+                <th>Avg score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {lowestAvgScorePlayers.map((row, i) => (
+                <tr key={i}>
+                  <td>
+                    <a href={`/${row.slug}`}>
+                      {row.firstName} {row.lastName}
+                    </a>
+                  </td>
+                  <td>{row.avgScore}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export async function getServerSideProps({ req, query }) {
+  const { auth: authToken } = req.cookies;
+  if (!authToken) {
+    return { notFound: true };
+  }
+  const account = await prisma.account.findUnique({ where: { authToken } });
+  if (!account || !ADMIN_EMAILS.includes(account.email)) {
+    return { notFound: true };
+  }
+
+  const minComps = Math.min(40, Math.max(1, parseInt(query.minComps, 10) || 10));
+
+  const [recentSignIns, topSubscribers, topFavoritedPlayers, mostActivePlayers, lowestAvgScorePlayers] = await Promise.all([
+    prisma.account.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: 10,
+      select: { email: true, createdAt: true },
+    }),
+
+    prisma.account.findMany({
+      take: 10,
+      orderBy: { favorites: { _count: 'desc' } },
+      select: {
+        email: true,
+        _count: { select: { favorites: true } },
+      },
+    }),
+
+    prisma.player.findMany({
+      take: 10,
+      orderBy: { favorites: { _count: 'desc' } },
+      select: {
+        firstName: true,
+        lastName: true,
+        slug: true,
+        _count: { select: { favorites: true } },
+      },
+    }),
+
+    prisma.player.findMany({
+      take: 10,
+      orderBy: { competitionScore: { _count: 'desc' } },
+      select: {
+        firstName: true,
+        lastName: true,
+        slug: true,
+        _count: { select: { competitionScore: true } },
+      },
+    }),
+
+    prisma.$queryRaw`
+      SELECT p."firstName", p."lastName", p.slug, AVG(pcs.score) / 10000.0 AS "avgScore"
+      FROM "Player" p
+      JOIN "PlayerCompetitionScore" pcs ON pcs."playerId" = p.id
+      GROUP BY p.id, p."firstName", p."lastName", p.slug
+      HAVING COUNT(*) >= ${minComps}
+      ORDER BY AVG(pcs.score) ASC
+      LIMIT 10
+    `,
+  ]);
+
+  return {
+    props: {
+      recentSignIns: recentSignIns.map(r => ({
+        email: r.email,
+        createdAt: r.createdAt.toISOString(),
+      })),
+      topSubscribers: topSubscribers.map(a => ({
+        email: a.email,
+        favoriteCount: a._count.favorites,
+      })),
+      topFavoritedPlayers: topFavoritedPlayers.map(p => ({
+        firstName: p.firstName,
+        lastName: p.lastName,
+        slug: p.slug,
+        favoriteCount: p._count.favorites,
+      })),
+      mostActivePlayers: mostActivePlayers.map(p => ({
+        firstName: p.firstName,
+        lastName: p.lastName,
+        slug: p.slug,
+        competitionCount: p._count.competitionScore,
+      })),
+      lowestAvgScorePlayers: lowestAvgScorePlayers.map(p => ({
+        firstName: p.firstName,
+        lastName: p.lastName,
+        slug: p.slug,
+        avgScore: parseFloat(p.avgScore).toFixed(1),
+      })),
+      minComps,
+    },
+  };
+}

--- a/pages/api/admin/competitions/[competitionId]/hide.js
+++ b/pages/api/admin/competitions/[competitionId]/hide.js
@@ -13,7 +13,7 @@ export default async function handler(req, res) {
     return res.status(400).send('No account');
   }
 
-  if (!account.email === 'henric.trotzig@gmail.com') {
+  if (account.email !== 'henric.trotzig@gmail.com') {
     return res.status(400).send('Not an admin account');
   }
 

--- a/styles.css
+++ b/styles.css
@@ -2703,3 +2703,63 @@ h2.player-big-name {
 .not-found-link:hover {
   opacity: 1;
 }
+
+.admin-dashboard {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.admin-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+@media (max-width: 600px) {
+  .admin-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.admin-select-label {
+  display: block;
+  font-size: 0.8rem;
+  opacity: 0.6;
+  margin-bottom: 0.5rem;
+  padding-left: 0.75rem;
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 2rem;
+  font-size: 0.9rem;
+}
+
+.admin-table th,
+.admin-table td {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.admin-table th {
+  font-weight: 600;
+  opacity: 0.6;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.admin-table th:last-child,
+.admin-table td:last-child {
+  text-align: right;
+}
+
+@media (prefers-color-scheme: dark) {
+  .admin-table th,
+  .admin-table td {
+    border-bottom-color: rgba(255, 255, 255, 0.1);
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `/admin/dashboard` restricted to `henric.trotzig@gmail.com` and `henric.persson@gmail.com`
- Five tables in a 2-column grid: latest sign-ups, most subscribed accounts, most favorited players, most competitions played, and lowest average score
- Lowest average score table has a 1–40 "min competitions" filter (default 10) that updates without scrolling
- Fixes broken admin auth check in `hide.js` (`!account.email ===` → `account.email !==`)

## Test plan

- [ ] Visit `/admin/dashboard` while signed in as an admin email — dashboard loads
- [ ] Visit while signed out or as a non-admin — returns 404
- [ ] Change the "Min competitions" select — table updates without page scrolling to top
- [ ] Verify number columns are right-aligned across all tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)