### PR TITLE
Increase left padding in Next event box

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -442,7 +442,7 @@ html.display-standalone nav {
   border-left: 5px solid var(--primary);
   align-items: start;
   column-gap: 16px;
-  padding: 5px 15px;
+  padding: 5px 15px 5px 20px;
 }
 .competitions li.next .competition::before {
   content: 'Next event';


### PR DESCRIPTION
## Summary
- Increases left padding in the "Next event" box from 15px to 20px for more breathing room between the left border and content

🤖 Generated with [Claude Code](https://claude.com/claude-code)