### PR TITLE
Make primary color more vibrant

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2,9 +2,9 @@
 
 :root,
 .pemb-page {
-  --primary: #e54e37;
-  --primary-light: #f4c7c1;
-  --primary-lightest: #ffe6e2;
+  --primary: #f03a20;
+  --primary-light: #f9c5be;
+  --primary-lightest: #fde8e5;
 
   --medium: #d0d0d0;
   --light: #f0f0f0;


### PR DESCRIPTION
## Summary
- Updates `--primary` from `#e54e37` to `#f03a20` for a more punchy red-orange
- Adjusts `--primary-light` and `--primary-lightest` to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)