### PR TITLE
Add favorite button to player scorecard dialog

### DIFF
--- a/src/CompetitionPage.js
+++ b/src/CompetitionPage.js
@@ -764,6 +764,8 @@ export default function CompetitionPage({
         data={data}
         onClose={() => setSelectedEntry(null)}
         collidingSlugs={collidingSlugs}
+        lastFavoriteChanged={lastFavoriteChanged}
+        onFavoriteChange={() => setLastFavoriteChanged(Date.now())}
       />
     </div>
   );

--- a/src/FavoriteButton.js
+++ b/src/FavoriteButton.js
@@ -67,7 +67,6 @@ export default function FavoriteButton({
           backgroundColor: isFavorite ? 'var(--primary)' : undefined,
           color: isFavorite ? '#fff' : undefined,
           borderColor: isFavorite ? 'var(--primary)' : 'currentColor',
-          minWidth: 170,
         }}
         onClick={clickHandler.bind(this, true)}
       >

--- a/src/PlayerDialog.js
+++ b/src/PlayerDialog.js
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
+import FavoriteButton from './FavoriteButton';
 import FlagIcon from './FlagIcon';
 import PlayerPhoto from './PlayerPhoto';
 import fixParValue from './fixParValue';
@@ -148,7 +149,7 @@ function DialogRound({ round, colors }) {
   );
 }
 
-export default function PlayerDialog({ entry, competition, data, onClose, collidingSlugs }) {
+export default function PlayerDialog({ entry, competition, data, onClose, collidingSlugs, lastFavoriteChanged, onFavoriteChange }) {
   const dialogRef = useRef(null);
   const mainRef = useRef(null);
   const [copied, setCopied] = useState(false);
@@ -401,6 +402,14 @@ export default function PlayerDialog({ entry, competition, data, onClose, collid
                   )}
                   {copied ? 'Copied!' : 'Share scorecard'}
                 </button>
+                {entry && (
+                  <FavoriteButton
+                    playerId={entry.MemberID}
+                    large
+                    lastFavoriteChanged={lastFavoriteChanged}
+                    onChange={onFavoriteChange}
+                  />
+                )}
               </div>
               <div className="player-profile-rounds">
                 {rounds.map(round => (

--- a/styles.css
+++ b/styles.css
@@ -495,7 +495,7 @@ html.display-standalone nav {
   grid-column-end: 4;
 }
 
-.leaderboard-page .favorite-button {
+.leaderboard-page .position .favorite-button {
   all: unset;
   cursor: pointer;
   position: absolute;
@@ -1159,6 +1159,18 @@ footer a:hover {
 .icon-button:disabled {
   filter: grayscale(1);
   cursor: default;
+}
+.favorite-button-large {
+  min-width: 170px;
+}
+.player-profile-share .favorite-button-large {
+  min-width: unset;
+  font-size: 14px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: none;
+  background: rgba(var(--text-rgb), 0.08);
+  color: var(--text);
 }
 .player-page-club {
   display: flex;
@@ -2619,6 +2631,10 @@ h2.player-big-name {
 .player-profile-share {
   padding-top: 6px;
   padding-bottom: 16px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
 }
 .player-dialog-share {
   all: unset;
@@ -2630,7 +2646,7 @@ h2.player-big-name {
   background: rgba(var(--text-rgb), 0.08);
   color: var(--text);
   font-size: 14px;
-  padding: 6px 12px;
+  padding: 10px 12px;
   user-select: none;
   transition: background 0.15s;
 }


### PR DESCRIPTION
## Summary

- Adds a `FavoriteButton` next to the "Share scorecard" button in the player dialog, so users can mark/unmark favorites from mobile (where the leaderboard row button is hidden)
- Moves `minWidth: 170` out of inline style into a `.favorite-button-large` CSS class so it can be overridden contextually
- Scopes `.leaderboard-page .favorite-button` to `.leaderboard-page .position .favorite-button`
- Styles the dialog favorite button to match the share button (same font size, padding, border-radius, background)

## Test plan

- [ ] Open a competition page and tap a player row to open the scorecard dialog
- [ ] Verify the favorite button appears next to the share button
- [ ] Tap to add/remove as favorite — star should toggle correctly
- [ ] Verify the player page large favorite button still has its `min-width`

🤖 Generated with [Claude Code](https://claude.com/claude-code)