### PR TITLE
Fix projected cut miscalculation when later rounds exist in field data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm run test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ Passwordless email-based sign-in. Flow: `auth/init.js` → email with code → `
 - `pnpm db:studio` — open Prisma Studio locally
 - `pnpm dev` — start dev server
 - `pnpm storybook` — start Storybook on port 6006
+- `pnpm test` — run unit tests (Node built-in test runner, no install needed)
 
 Use `production.env` file (gitignored) for prod env vars with the `:prod` script variants. Local development benefits from copying an .env file from the workspace source/root.
 
@@ -64,6 +65,7 @@ Use `production.env` file (gitignored) for prod env vars with the `:prod` script
 
 - Components live in `src/` as `.js` files (React, no TypeScript)
 - ESM modules use `.mjs` extension
+- Unit-testable pure logic lives in `*.mjs` files alongside components; test files are `*.test.mjs` and run with the Node built-in test runner (`node --test`)
 - Slugs are generated from player names and deduplicated with MD5 suffix if colliding
 - GolfBox API responses use JSONP format — parsed with `scripts/utils/parseJson.mjs`
 - Dark mode is supported via CSS (check `styles.css` for `prefers-color-scheme`)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "postinstall": "prisma generate",
-    "find-oom-id": "dotenv node scripts/find-oom-id.mjs"
+    "find-oom-id": "dotenv node scripts/find-oom-id.mjs",
+    "test": "node --test src/**/*.test.mjs"
   },
   "dependencies": {
     "@prisma/client": "^6.8.2",

--- a/src/CutInfo.js
+++ b/src/CutInfo.js
@@ -1,12 +1,5 @@
 import React from 'react';
-
-
-function formatProjectedScore(value) {
-  const rounded = Math.round(value);
-  if (rounded === 0) return 'E';
-  if (rounded > 0) return `+${rounded}`;
-  return `${rounded}`;
-}
+import { getProjectedCutScore } from './cutUtils.mjs';
 
 function getCutConfig(data) {
   const classes = data.CompetitionData && data.CompetitionData.Classes;
@@ -14,70 +7,6 @@ function getCutConfig(data) {
     return null;
   }
   return classes[0].Cut;
-}
-
-// Count total holes played by a single entry, using Rounds data when available.
-// HoleValue from ScoringToPar can be a negative tee-time timestamp between rounds,
-// so we prefer counting from the per-round IsCompleted flag and HoleScores.
-function countHolesPlayedForEntry(entry, activeRound) {
-  if (entry.Rounds) {
-    let total = 0;
-    for (const round of Object.values(entry.Rounds)) {
-      if (round.IsCompleted) {
-        total += 18;
-      } else if (round.HoleScores) {
-        // Count individual hole scores, excluding summary keys (H-OUT, H-IN, H-TOTAL)
-        total += Object.keys(round.HoleScores).filter(k => !k.startsWith('H-')).length;
-      }
-    }
-    return total;
-  }
-  // Fallback when Rounds data isn't available: clamp HoleValue to 0 in case it
-  // is a negative tee-time timestamp, then add holes from completed rounds.
-  const currentRoundHoles = Math.max(
-    (entry.ScoringToPar && entry.ScoringToPar.HoleValue) || 0,
-    0,
-  );
-  return currentRoundHoles + (activeRound - 1) * 18;
-}
-
-function getProjectedCutScore(cutConfig, cut, entries, activeRound) {
-  if (!cutConfig || !cutConfig.Enabled || !cutConfig.Limit || !entries) {
-    return null;
-  }
-  const afterRound = cut.AfterRound || cutConfig.AfterRound;
-  if (!afterRound) {
-    return null;
-  }
-  const cutEntry = entries.find(
-    e => e.Position && e.Position.Actual === cutConfig.Limit,
-  );
-  if (!cutEntry || !cutEntry.ScoringToPar) {
-    return null;
-  }
-  const currentScore = cutEntry.ScoringToPar.ToParValue / 10000;
-  // Compute field completion percentage: total holes played by all entries
-  // divided by total holes the full field is expected to play before the cut.
-  const totalFieldHoles = entries.length * afterRound * 18;
-  const holesPlayedByField = entries.reduce((sum, e) => {
-    return sum + countHolesPlayedForEntry(e, activeRound);
-  }, 0);
-  if (!holesPlayedByField || !totalFieldHoles) {
-    return null;
-  }
-
-  // During round 1, don't show projected cut until 75% of round 1 holes are played
-  if (activeRound === 1 && holesPlayedByField / (entries.length * 18) < 0.75) {
-    return null;
-  }
-
-  const fieldCompletionRatio = holesPlayedByField / totalFieldHoles;
-  const projected = currentScore + currentScore * fieldCompletionRatio;
-
-  const cleanedProjected =
-    projected > 0 ? Math.floor(projected) : Math.ceil(projected);
-
-  return formatProjectedScore(cleanedProjected);
 }
 
 

--- a/src/cutUtils.mjs
+++ b/src/cutUtils.mjs
@@ -1,0 +1,75 @@
+export function formatProjectedScore(value) {
+  const rounded = Math.round(value);
+  if (rounded === 0) return 'E';
+  if (rounded > 0) return `+${rounded}`;
+  return `${rounded}`;
+}
+
+// Count total holes played by a single entry up to and including afterRound,
+// using Rounds data when available.
+// HoleValue from ScoringToPar can be a negative tee-time timestamp between rounds,
+// so we prefer counting from the per-round IsCompleted flag and HoleScores.
+export function countHolesPlayedForEntry(entry, activeRound, afterRound) {
+  if (entry.Rounds) {
+    let total = 0;
+    for (const [key, round] of Object.entries(entry.Rounds)) {
+      const roundNum = parseInt(key.replace('R', ''), 10);
+      if (roundNum > afterRound) continue;
+      if (round.IsCompleted) {
+        total += 18;
+      } else if (round.HoleScores) {
+        // Count individual hole scores, excluding summary keys (H-OUT, H-IN, H-TOTAL)
+        total += Object.keys(round.HoleScores).filter(k => !k.startsWith('H-')).length;
+      }
+    }
+    return total;
+  }
+  // Fallback when Rounds data isn't available: clamp HoleValue to 0 in case it
+  // is a negative tee-time timestamp, then add holes from completed rounds.
+  const currentRoundHoles = Math.max(
+    (entry.ScoringToPar && entry.ScoringToPar.HoleValue) || 0,
+    0,
+  );
+  // Only count completed rounds up to afterRound (rounds beyond the cut don't count).
+  const completedRoundsBeforeCut = Math.min(activeRound - 1, afterRound);
+  return currentRoundHoles + completedRoundsBeforeCut * 18;
+}
+
+export function getProjectedCutScore(cutConfig, cut, entries, activeRound) {
+  if (!cutConfig || !cutConfig.Enabled || !cutConfig.Limit || !entries) {
+    return null;
+  }
+  const afterRound = cut.AfterRound || cutConfig.AfterRound;
+  if (!afterRound) {
+    return null;
+  }
+  const cutEntry = entries.find(
+    e => e.Position && e.Position.Actual === cutConfig.Limit,
+  );
+  if (!cutEntry || !cutEntry.ScoringToPar) {
+    return null;
+  }
+  const currentScore = cutEntry.ScoringToPar.ToParValue / 10000;
+  // Compute field completion percentage: total holes played by all entries
+  // divided by total holes the full field is expected to play before the cut.
+  const totalFieldHoles = entries.length * afterRound * 18;
+  const holesPlayedByField = entries.reduce((sum, e) => {
+    return sum + countHolesPlayedForEntry(e, activeRound, afterRound);
+  }, 0);
+  if (!holesPlayedByField || !totalFieldHoles) {
+    return null;
+  }
+
+  // During round 1, don't show projected cut until 75% of round 1 holes are played
+  if (activeRound === 1 && holesPlayedByField / (entries.length * 18) < 0.75) {
+    return null;
+  }
+
+  const fieldCompletionRatio = holesPlayedByField / totalFieldHoles;
+  const projected = currentScore + currentScore * fieldCompletionRatio;
+
+  const cleanedProjected =
+    projected > 0 ? Math.floor(projected) : Math.ceil(projected);
+
+  return formatProjectedScore(cleanedProjected);
+}

--- a/src/cutUtils.test.mjs
+++ b/src/cutUtils.test.mjs
@@ -1,0 +1,154 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { countHolesPlayedForEntry, getProjectedCutScore } from './cutUtils.mjs';
+
+describe('countHolesPlayedForEntry', () => {
+  describe('using Rounds data', () => {
+    it('counts holes from completed rounds up to afterRound', () => {
+      const entry = {
+        Rounds: {
+          R1: { IsCompleted: true },
+          R2: { IsCompleted: true },
+          R3: { IsCompleted: true },
+          R4: { IsCompleted: true },
+        },
+      };
+      // Cut after round 2 — only R1 and R2 should count
+      assert.equal(countHolesPlayedForEntry(entry, 2, 2), 36);
+    });
+
+    it('ignores rounds beyond afterRound even if completed', () => {
+      const entry = {
+        Rounds: {
+          R1: { IsCompleted: true },
+          R2: { IsCompleted: true },
+          R3: { IsCompleted: true },
+        },
+      };
+      assert.equal(countHolesPlayedForEntry(entry, 2, 2), 36);
+    });
+
+    it('counts individual hole scores for in-progress round', () => {
+      const entry = {
+        Rounds: {
+          R1: { IsCompleted: true },
+          R2: {
+            IsCompleted: false,
+            HoleScores: { H1: 4, H2: 3, H3: 5, 'H-OUT': 12, 'H-IN': null, 'H-TOTAL': 12 },
+          },
+        },
+      };
+      // R1 complete (18) + 3 holes in R2 = 21
+      assert.equal(countHolesPlayedForEntry(entry, 2, 2), 21);
+    });
+
+    it('does not count holes from in-progress round beyond afterRound', () => {
+      const entry = {
+        Rounds: {
+          R1: { IsCompleted: true },
+          R2: { IsCompleted: true },
+          R3: {
+            IsCompleted: false,
+            HoleScores: { H1: 4, H2: 3 },
+          },
+        },
+      };
+      // R3 is beyond afterRound=2 and must be ignored
+      assert.equal(countHolesPlayedForEntry(entry, 3, 2), 36);
+    });
+
+    it('returns 0 when no rounds are completed and none have hole scores', () => {
+      const entry = {
+        Rounds: {
+          R1: { IsCompleted: false },
+          R2: { IsCompleted: false },
+        },
+      };
+      assert.equal(countHolesPlayedForEntry(entry, 1, 2), 0);
+    });
+  });
+
+  describe('fallback (no Rounds data)', () => {
+    it('counts current round holes plus completed rounds before cut', () => {
+      const entry = { ScoringToPar: { HoleValue: 9 } };
+      // activeRound=2, afterRound=2 → 1 completed round (R1) + 9 holes in R2
+      assert.equal(countHolesPlayedForEntry(entry, 2, 2), 27);
+    });
+
+    it('clamps completed rounds at afterRound', () => {
+      const entry = { ScoringToPar: { HoleValue: 5 } };
+      // activeRound=3, afterRound=2 → only 2 completed rounds counted (not 2)
+      assert.equal(countHolesPlayedForEntry(entry, 3, 2), 41);
+    });
+
+    it('clamps negative HoleValue (tee-time timestamp) to 0', () => {
+      const entry = { ScoringToPar: { HoleValue: -12345 } };
+      assert.equal(countHolesPlayedForEntry(entry, 2, 2), 18);
+    });
+
+    it('handles missing ScoringToPar', () => {
+      const entry = {};
+      assert.equal(countHolesPlayedForEntry(entry, 2, 2), 18);
+    });
+  });
+});
+
+describe('getProjectedCutScore', () => {
+  function makeEntry(positionActual, toParValue, roundsData) {
+    return {
+      Position: { Actual: positionActual },
+      ScoringToPar: { ToParValue: toParValue, HoleValue: 18 },
+      Rounds: roundsData,
+    };
+  }
+
+  const cutConfig = { Enabled: true, Limit: 2, AfterRound: 2 };
+  const cut = { AfterRound: 2 };
+
+  it('returns null when cutConfig is missing', () => {
+    assert.equal(getProjectedCutScore(null, cut, [], 2), null);
+  });
+
+  it('returns null when no entry sits at the cut line', () => {
+    const entries = [makeEntry(1, -50000, { R1: { IsCompleted: true }, R2: { IsCompleted: true } })];
+    assert.equal(getProjectedCutScore(cutConfig, cut, entries, 2), null);
+  });
+
+  it('does not exceed 1.0 field completion when later rounds have data', () => {
+    // Bug scenario: 4-round tournament, cut after R2, we are in R2.
+    // R3 and R4 exist in the data but should be ignored.
+    const entries = [
+      makeEntry(1, -80000, {
+        R1: { IsCompleted: true },
+        R2: { IsCompleted: true },
+        R3: { IsCompleted: true }, // should be ignored
+        R4: { IsCompleted: true }, // should be ignored
+      }),
+      makeEntry(2, -50000, {
+        R1: { IsCompleted: true },
+        R2: { IsCompleted: true },
+        R3: { IsCompleted: true }, // should be ignored
+        R4: { IsCompleted: true }, // should be ignored
+      }),
+    ];
+    // If R3/R4 were counted, holesPlayedByField would be 4*2*18=144
+    // vs totalFieldHoles=2*2*18=72, giving ratio=2.0 and a wildly wrong projection.
+    // With the fix, ratio=1.0 and projected = currentScore * 2 = -10.
+    const result = getProjectedCutScore(cutConfig, cut, entries, 2);
+    assert.notEqual(result, null);
+    // currentScore for cut entry (#2) = -50000/10000 = -5
+    // fieldCompletionRatio = (18+18)/(2*2*18) ... wait both players have R1+R2 completed
+    // holesPlayed = 2*36=72, totalFieldHoles=2*2*18=72, ratio=1.0
+    // projected = -5 + (-5 * 1.0) = -10
+    assert.equal(result, '-10');
+  });
+
+  it('returns null during round 1 when fewer than 75% of holes are played', () => {
+    const entries = [
+      makeEntry(1, -20000, { R1: { IsCompleted: false, HoleScores: { H1: 3 } } }),
+      makeEntry(2, -10000, { R1: { IsCompleted: false, HoleScores: { H1: 4 } } }),
+    ];
+    // 2 holes played out of 2*18=36 → 5.5% < 75%
+    assert.equal(getProjectedCutScore(cutConfig, cut, entries, 1), null);
+  });
+});


### PR DESCRIPTION
## What changed

The projected cut score was wrong when a 4-round tournament's GolfBox API response included round 3/4 data during round 2 (before the cut). `countHolesPlayedForEntry` iterated over **all** rounds unconditionally, so `holesPlayedByField` could exceed `totalFieldHoles` (which correctly caps at `afterRound`). This pushed the field-completion ratio above 1.0 and produced a wildly skewed projection.

**Fix:** filter by round number when using `Rounds` data (skip rounds where `roundNum > afterRound`), and clamp the fallback path's completed-round count to `min(activeRound - 1, afterRound)`.

## Other changes

- Extracted the pure calculation functions (`countHolesPlayedForEntry`, `getProjectedCutScore`, `formatProjectedScore`) from `CutInfo.js` into `src/cutUtils.mjs` so they can be unit-tested without a JSX transform.
- Added `src/cutUtils.test.mjs` — 13 tests via Node's built-in test runner, including a dedicated regression test for this bug.
- Added `.github/workflows/test.yml` to run `npm test` in CI on every push and PR.
- Added `pnpm test` to CLAUDE.md and noted the `.mjs` / `.test.mjs` convention.

## Reviewer notes

The test that directly covers the bug is `does not exceed 1.0 field completion when later rounds have data` in `getProjectedCutScore`. It constructs a 2-player field where all 4 rounds are marked `IsCompleted: true` but `afterRound = 2`, and asserts the projection is `-10` (not some inflated value).