### PR TITLE
Redesign start page intro with bolder title and copy

### DIFF
--- a/src/StartPage.js
+++ b/src/StartPage.js
@@ -129,9 +129,11 @@ export default function StartPage({
         />
       </Head>
       <div className="competitions">
-        <h2>{process.env.NEXT_PUBLIC_INTRO_TITLE}</h2>
+        <h1 className="intro-title">A launchpad for nordic golfers.</h1>
         <p className="page-desc">
-          {process.env.NEXT_PUBLIC_INTRO} Follow your{' '}
+          The Cutter &amp; Buck Tour is the first step for Nordic professional
+          golfers on their way to the Challenge Tour and the DP World Tour. We
+          track the scores so that you can follow your{' '}
           <Link href="/players">favorite players</Link> and get the latest
           updates <Link href="/profile">straight in your inbox</Link>.
         </p>

--- a/styles.css
+++ b/styles.css
@@ -87,6 +87,17 @@ h2 {
   margin-bottom: 0;
 }
 
+.intro-title {
+  padding: 80px 10px 16px;
+  margin: 0;
+  line-height: 1.1;
+  font-size: 42px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+  font-family: Georgia, 'Times New Roman', serif;
+  max-width: 390px;
+}
+
 h3 {
   font-size: 16px;
   font-weight: normal;
@@ -112,7 +123,7 @@ button {
   margin: 0;
   opacity: 0.7;
   line-height: 1.5;
-  margin-bottom: 10px;
+  margin-bottom: 72px;
 }
 .page-desc a {
   color: inherit;


### PR DESCRIPTION
## Summary

- Replaces the generic env-var h2 title with a hand-crafted h1: "A launchpad for nordic golfers."
- Uses a Georgia serif font stack for display impact, with generous spacing above and below
- Rewrites the intro copy to explain the tour's role as a stepping stone to the Challenge Tour and DP World Tour

## Test plan

- [ ] Visit the home page and verify the new title and intro text render correctly
- [ ] Check on mobile that the title wraps nicely ("nordic golfers" on second line)
- [ ] Verify dark mode looks good

🤖 Generated with [Claude Code](https://claude.com/claude-code)