### PR TITLE
Show inline position on OOM page for small screens

### DIFF
--- a/pages/oom.js
+++ b/pages/oom.js
@@ -43,6 +43,9 @@ function Player({ entry, onFavorite, lastFavoriteChanged, collidingSlugs }) {
           />
         </span>
         <span>
+          {entry.Position ? (
+            <span className="position-inline">{entry.Position}</span>
+          ) : null}
           {entry.FirstName} {entry.LastName}
           <br />
           <span className="club">{entry.ClubName}</span>

--- a/styles.css
+++ b/styles.css
@@ -929,7 +929,8 @@ footer a:hover {
   display: none;
 }
 @media (max-width: 500px) {
-  .leaderboard-page .player .player-link {
+  .leaderboard-page .player .player-link,
+  .oom .player {
     grid-template-columns: auto 80px;
   }
   .leaderboard-page .position {


### PR DESCRIPTION
## Summary
- The `.position` column (containing position number + favorite button) is hidden on screens <500px. The competition page already renders the position inline before the player's name, but the OOM page wasn't updated — leaving an empty 30px column and no visible rank.
- Render `<span class="position-inline">` before the player name on `pages/oom.js`.
- Extend the `<500px` grid override to also target `.oom .player`, so the column collapses to `auto 80px`.

## Test plan
- [ ] Open the OOM page (`/oom`) on a viewport ≤500px and verify each row shows the position inline before the player name with no empty left column.
- [ ] On viewports >500px, layout is unchanged (position + favorite button in their own column).
- [ ] Spot-check competition pages still render correctly at both breakpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)