### PR TITLE
Improve dark mode contrast for leaderboard scorecard

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2816,3 +2816,33 @@ h2.player-big-name {
     border-bottom-color: rgba(255, 255, 255, 0.1);
   }
 }
+
+@media (prefers-color-scheme: dark) {
+  .round-score {
+    opacity: 0.9;
+  }
+  .round-score.eagle {
+    opacity: 1;
+    color: #ff7a64;
+    border-color: #ff7a64;
+  }
+  .round-score.eagle:after {
+    border-color: #ff7a64;
+    color: #ff7a64;
+  }
+  .round-score.hio {
+    background-color: #ff7a64;
+  }
+  .round-score.bogey-plus:after {
+    border-color: rgba(var(--text-rgb), 0.5);
+  }
+  .round-total.under-par,
+  .leaderboard-score.under-par,
+  .player-round-scorecard-val.under-par {
+    color: #ff7a64;
+  }
+  .player-round-scorecard > *,
+  .player-round-scorecard-hole-last {
+    opacity: 0.9;
+  }
+}


### PR DESCRIPTION
## Summary
- Bump `.round-score` opacity from 0.5 → 0.9 in dark mode so hole-by-hole scores are legible
- Swap under-par red `#e54e37` → brighter `#ff7a64` for round totals, eagle rings, and HIO badges in dark mode (the original red had poor contrast against the `#222` background)
- Fix the bogey-plus inner ring (was `rgba(0,0,0,0.5)` — invisible on dark) to use the text color
- Lift `.player-round-scorecard` cell opacity from 0.7 → 0.9 so the expanded scorecard reads better too

All changes live inside a `prefers-color-scheme: dark` block — light mode is untouched.

## Test plan
- [ ] Open a competition leaderboard in dark mode and confirm hole-by-hole scores are easier to read
- [ ] Check that under-par totals and eagle/HIO markers stand out without losing the red identity
- [ ] Open a player's full scorecard (PlayerDialog) in dark mode and confirm cells are sharper
- [ ] Verify light mode is visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)