### PR TITLE
Fix pnpm install: add missing packages field to workspace config

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 allowBuilds:
   '@prisma/client': true
   '@prisma/engines': true


### PR DESCRIPTION
## Summary
- `pnpm-workspace.yaml` was missing the required `packages` field, causing `pnpm install --frozen-lockfile` to fail with `packages field missing or empty`
- Added `packages: ['.']` to declare the root as the workspace package

## Test plan
- [ ] Run `pnpm install --frozen-lockfile` — should complete without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)