### PR TITLE
Replace home-page youtubers section with per-player links

### DIFF
--- a/pages/[id].js
+++ b/pages/[id].js
@@ -11,6 +11,7 @@ import SignInForm from '../src/SignInForm';
 import fixParValue from '../src/fixParValue';
 import formatCompetitionName from '../src/formatCompetitionName';
 import generateSlug from '../src/generateSlug.mjs';
+import getPlayerLinks from '../src/playerLinks';
 import ordinal from '../src/ordinal';
 import prisma from '../src/prisma';
 import useData from '../src/useData';
@@ -42,6 +43,7 @@ export default function PlayerPage({
     setIsFavorite(localStorage.getItem(player.id));
   }, [player]);
 
+  const playerLinks = getPlayerLinks(player);
   const scoresBySeason = getScoresBySeason(player.competitionScore);
   const season =
     selectedSeason ||
@@ -139,6 +141,23 @@ export default function PlayerPage({
       ) : null}
 
       <PlayerStatsChart competitionScores={player.competitionScore} />
+
+      {playerLinks.length > 0 && (
+        <>
+          <h2 style={{ paddingBottom: 0 }}>Links</h2>
+          <div className="page-margin" style={{ paddingTop: 0 }}>
+            <ul className="player-page-links">
+              {playerLinks.map(link => (
+                <li key={link.url}>
+                  <a href={link.url} target="_blank" rel="noopener noreferrer">
+                    {link.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      )}
 
       <h2>Results</h2>
       <div className="page-margin">

--- a/src/StartPage.js
+++ b/src/StartPage.js
@@ -11,36 +11,6 @@ import formatCompetitionName from './formatCompetitionName';
 import ensureDates from './ensureDates.js';
 import { preloadJsonPData } from './fetchJsonP.js';
 
-const youtubers = [
-  {
-    name: 'Stefan Idstam',
-    url: 'https://www.youtube.com/@stefanidstamgolf',
-    avatar: {
-      url: '/avatar-stefan-idstam.jpg',
-      width: 320,
-      height: 320,
-    },
-  },
-  {
-    name: 'Adam Andersson',
-    url: 'https://adamanderssongolf.com/',
-    avatar: {
-      url: 'https://adamanderssongolf.com/wp-content/uploads/sb-instagram-feed-images/517973384_18507897097053711_8842400633805056808_nfull.webp',
-      width: 640,
-      height: 843,
-    },
-  },
-  {
-    name: 'Fredrik Lindblom',
-    url: 'https://www.youtube.com/@FredrikandHannah',
-    avatar: {
-      url: '/avatar-fredrik-lindblom.jpg',
-      width: 683,
-      height: 683,
-    },
-  },
-];
-
 export default function StartPage({
   pastCompetitions,
   upcomingCompetitions,
@@ -161,32 +131,6 @@ export default function StartPage({
             </Link>
           </>
         )}
-
-        <h3 style={{ marginBottom: 0 }}>More from the players</h3>
-        <p className="page-desc">
-          Support players by following them on their social media accounts,
-          subscribing to their channels and watching their videos.
-        </p>
-        <ul className="youtubers">
-          {youtubers.map(y => (
-            <li key={y.name} className="youtuber">
-              <a
-                href={y.url}
-                className="youtuber-link"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <img
-                  src={y.avatar.url}
-                  alt={y.name}
-                  width={y.avatar.width}
-                  height={y.avatar.height}
-                />
-                {y.name}
-              </a>
-            </li>
-          ))}
-        </ul>
 
         {pastCompetitions.length > 0 && (
           <>

--- a/src/playerLinks.js
+++ b/src/playerLinks.js
@@ -1,0 +1,16 @@
+const linksByName = {
+  'Stefan Idstam': [
+    { label: 'YouTube', url: 'https://www.youtube.com/@stefanidstamgolf' },
+  ],
+  'Adam Andersson': [
+    { label: 'Website', url: 'https://adamanderssongolf.com/' },
+  ],
+  'Fredrik Lindblom': [
+    { label: 'YouTube', url: 'https://www.youtube.com/@FredrikandHannah' },
+  ],
+};
+
+export default function getPlayerLinks(player) {
+  const key = `${player.firstName} ${player.lastName}`;
+  return linksByName[key] || [];
+}

--- a/styles.css
+++ b/styles.css
@@ -1254,6 +1254,26 @@ footer a:hover {
   background-position: center;
   background-repeat: no-repeat;
 }
+.player-page-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.player-page-links a {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(var(--text-rgb), 0.08);
+  color: var(--text);
+  text-decoration: none;
+  font-size: 13px;
+}
+.player-page-links a:hover {
+  background: rgba(var(--text-rgb), 0.15);
+}
 .player-page-oom {
   color: inherit;
   text-align: right;
@@ -2087,31 +2107,6 @@ body .pemb-page {
   width: 100%;
   height: 100%;
   border-radius: 4px;
-}
-
-.youtubers {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 20px;
-}
-.youtuber-link {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-decoration: none;
-  color: inherit;
-  gap: 10px;
-  text-align: center;
-  font-size: 13px;
-
-  & img {
-    width: 100%;
-    height: auto;
-    aspect-ratio: 1/1;
-    object-fit: cover;
-    border-radius: 50%;
-  }
 }
 
 .player-big-position {


### PR DESCRIPTION
## Summary
- Remove the outdated "More from the players" block (and its `youtubers` data + CSS) from the home page
- Add a small `playerLinks` module mapping players to their website/social links
- Render those links in a new "Links" section on the individual player page

## Test plan
- [ ] Visit `/` and confirm the "More from the players" section is gone
- [ ] Visit `/stefan-idstam`, `/adam-andersson`, `/fredrik-lindblom` and confirm a "Links" section appears with the expected link
- [ ] Visit a player without a configured link and confirm no "Links" section is rendered
- [ ] Verify the gap between the "Links" heading and the chip list looks tight in light & dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)